### PR TITLE
cleanup: drop the never-read profile passwd field

### DIFF
--- a/profile.c
+++ b/profile.c
@@ -32,7 +32,6 @@ vwm_profile_init(vwm_t *vwm)
     if(user_info != NULL)
     {
         profile->login = strdup(user_info->pw_name);
-        profile->passwd = strdup(user_info->pw_passwd);
         profile->home = strdup(user_info->pw_dir);
     }
 

--- a/profile.h
+++ b/profile.h
@@ -5,7 +5,6 @@ struct _vwm_profile_s
 {
     uid_t   user;
     char    *login;
-    char    *passwd;
     char    *home;
     char    *rc_file;
     char    *mod_dir;


### PR DESCRIPTION
vwm_profile_init has copied getpwuid()->pw_passwd into profile->passwd since 2017 (ecc8a2e, when the profile was first populated to locate the home dir for the config file).  The field never gained an accessor and is read nowhere; the value is inert regardless: on shadow-password systems getpwuid()->pw_passwd is just "x" (the real hash lives in /etc/shadow), and the lock screen delegates auth to vlock/PAM.  Remove the dead field and its strdup -- also drops a small never-freed alloc.