### PR TITLE
cleanup: use strdup for the verbatim panel message copy

### DIFF
--- a/panel.c
+++ b/panel.c
@@ -669,7 +669,7 @@ vwm_panel_message_add(char *msg, int timeout)
         timeout = VWM_PANEL_MSG_TTL_MAX;
 
     vwm_panel_msg = (VWM_PANEL_MSG*)calloc(1, sizeof(VWM_PANEL_MSG));
-    vwm_panel_msg->msg = strdup_printf("%s",msg);
+    vwm_panel_msg->msg = strdup(msg);
     vwm_panel_msg->msg_len = strlen(msg);
     vwm_panel_msg->timeout = timeout;
     vwm_panel_msg->touch_val = timeout;


### PR DESCRIPTION
vwm_panel_message_add copied its message with strdup_printf("%s", msg), which runs two vsnprintf passes (measure + format) plus varargs setup to produce exactly what strdup does in one strlen + copy.  msg is NULL-guarded just above (line 663) so strdup is safe, and the result is byte-identical.  Cold path, so the win is negligible -- this is mainly for clarity.  The other strdup_printf sites use real multi-token formats and are left untouched.