### PR TITLE
cleanup: stack-allocate vwm_sigset, return void

### DIFF
--- a/private.h
+++ b/private.h
@@ -83,7 +83,7 @@ struct _vwm_s
 #define  SPRITE_ROWS(x)    (sizeof(x) / sizeof(x[0]))
 #define  SPRITE_COLS(x)    (sizeof(x[0]) / (sizeof(x[0][0])))
 
-struct sigaction* vwm_sigset(int signum, sighandler_t handler);
+void vwm_sigset(int signum, sighandler_t handler);
 
 /* border decoration callback for vk_window_t */
 void    vwm_window_decorate(vk_window_t *window, WINDOW *canvas, void *data);

--- a/signals.c
+++ b/signals.c
@@ -33,31 +33,24 @@ static struct sigaction vwm_winch_prev;
 static int              vwm_winch_prev_valid = 0;
 
 /*
-   pass back the struct sigaction so that the memory can be release if we
-   need to replace the sighandler.  not use now, but maybe useful in the
-   future.
+   install handler for signum, preserving the current signal mask and
+   leaving sa_flags clear (matches the old calloc-zeroed sigaction).
 */
-struct sigaction*
+void
 vwm_sigset(int signum, sighandler_t handler)
 {
-    struct sigaction    *action;
+    struct sigaction    action;
     sigset_t            old_mask;
 
-    if(handler == NULL) return NULL;
+    if(handler == NULL) return;
 
-    action = (struct sigaction*)calloc(1,sizeof(struct sigaction));
+    memset(&action, 0, sizeof(action));
 
     // retrieve current signal mask
     sigprocmask(0,NULL,&old_mask);
-    action->sa_handler = handler;
-    action->sa_mask = old_mask;
-    sigaction(signum,(const struct sigaction*)action,NULL);
-
-    free(action);
-
-    (void)signum;
-
-    return NULL;
+    action.sa_handler = handler;
+    action.sa_mask = old_mask;
+    sigaction(signum, &action, NULL);
 }
 
 #ifdef _DEBUG

--- a/signals.h
+++ b/signals.h
@@ -5,7 +5,7 @@
 
 extern volatile sig_atomic_t vwm_winch_pending;
 
-struct sigaction* vwm_sigset(int signum, sighandler_t handler);
+void vwm_sigset(int signum, sighandler_t handler);
 
 void 	vwm_backtrace(int signum);
 void 	vwm_SIGIO(int signum);


### PR DESCRIPTION
vwm_sigset heap-allocated a struct sigaction, filled it, installed it, then freed it and returned NULL.  The struct sigaction* return type and the heap alloc were leftovers from an abandoned design (per the old comment) to hand the action back to the caller for a later restore -- never built, and all 7 callers ignore the return.

Use a stack local instead, memset to 0 first to preserve calloc's zeroing (sa_flags must stay clear).  The object never escapes: sigaction() copies it into the kernel before return.  This drops 7 calloc/free pairs at startup plus the unchecked-calloc crash-on-OOM path, and makes the signature honest.  Also removes the dead (void)signum (signum is used at the sigaction call) and the stale comment.  Prototype updated in both signals.h and private.h.