### PR TITLE
cleanup: remove the vestigial panel freeze/thaw mechanism

### DIFF
--- a/panel.c
+++ b/panel.c
@@ -66,8 +66,6 @@ vwm_panel_init(vwm_t *vwm)
     if(panel_data != NULL) return;
 
     vwm_panel = (VWM_PANEL*)calloc(1, sizeof(VWM_PANEL));
-    vwm_panel->tick_rate = 2;
-    vwm_panel->thaw_rate = 3;
     panel_data = vwm_panel;
 
     getmaxyx(vk_screen_get_window(vwm->screen), max_y, max_x);
@@ -678,12 +676,6 @@ vwm_panel_message_add(char *msg, int timeout)
     list_add(&vwm_panel_msg->list, &vwm_panel->msg_list);
     vwm_panel->msg_count++;
 
-    if(vwm_panel->msg_count == 1)
-    {
-        vwm_panel->state |= VWM_PANEL_STATE_FROZEN;
-        vwm_panel->thaw_timer = vwm_panel->thaw_rate;
-    }
-
     return vwm_panel_msg->msg_id.msg_handle;
 }
 
@@ -776,8 +768,6 @@ vwm_panel_message_promote(uintmax_t msg_id)
     if(vwm_panel_msg != NULL)
     {
         list_move(pos, &vwm_panel->msg_list);
-
-        vwm_panel->thaw_timer = vwm_panel->thaw_rate;
     }
 
     return 0;

--- a/panel.h
+++ b/panel.h
@@ -9,8 +9,6 @@
 
 #include "list.h"
 
-#define  VWM_PANEL_STATE_FROZEN  (1<<1)
-
 #define  VWM_PANEL_MSG_TTL_MAX   30
 
 typedef struct
@@ -36,12 +34,7 @@ typedef struct
     vk_marquee_t        *status_marquee;
     vk_label_t          *version_label;
 
-    int32_t             tick_rate;
-    int32_t             freeze_time;
-    int32_t             thaw_timer;
-    int16_t             thaw_rate;
     int32_t             clock;
-    uint32_t            state;
 }
 VWM_PANEL;
 


### PR DESCRIPTION
vwm_panel_message_add and _touch set a FROZEN state bit and a thaw_timer countdown when a message was posted, meaning to hold a fresh message visible for a few ticks before rotating.  The consumer half was never built: vwm_panel_ON_CLOCK_TICK -- the per-tick handler that would decrement the timer and clear FROZEN -- references none of it, and nothing anywhere reads the panel state or thaw_timer.  So the panel got marked frozen and never thawed, with no observable effect since the state was write-only.

Remove the write-only fields (tick_rate, freeze_time, thaw_timer, thaw_rate, state) and the VWM_PANEL_STATE_FROZEN define, plus the three write sites.  The live clock field (drives the tick cadence) and msg_count (only the if(msg_count==1) trigger goes; the counter stays) are untouched, as is the list_move message-promote.  No behaviour change.