### PR TITLE
cleanup: use vk_listbox_reset() for the full-clear rebuilds

### DIFF
--- a/manage_apps.c
+++ b/manage_apps.c
@@ -405,11 +405,8 @@ static void
 listbox_rebuild(void)
 {
     int i;
-    int count;
 
-    count = vk_listbox_get_item_count(app_listbox);
-    for(i = count - 1; i >= 0; i--)
-        vk_listbox_remove_item(app_listbox, i);
+    vk_listbox_reset(app_listbox);
 
     for(i = 0; i < model->count; i++)
     {

--- a/manage_hotkeys.c
+++ b/manage_hotkeys.c
@@ -311,16 +311,13 @@ model_load_from_config(const char *path)
 static void
 rebuild_listbox(void)
 {
-    int     count;
     int     i;
     int     lb_idx = 0;
     int     last_cat = -1;
     char    display[ITEM_WIDTH + 32];
     char    keybuf[32];
 
-    count = vk_listbox_get_item_count(hotkey_listbox);
-    for(i = count - 1; i >= 0; i--)
-        vk_listbox_remove_item(hotkey_listbox, i);
+    vk_listbox_reset(hotkey_listbox);
 
     for(i = 0; i < NUM_HOTKEYS; i++)
     {

--- a/manage_settings.c
+++ b/manage_settings.c
@@ -462,11 +462,8 @@ static void
 rebuild_listbox(void)
 {
     int i;
-    int count;
 
-    count = vk_listbox_get_item_count(settings_listbox);
-    for(i = count - 1; i >= 0; i--)
-        vk_listbox_remove_item(settings_listbox, i);
+    vk_listbox_reset(settings_listbox);
 
     for(i = 0; i < active_setting_count(); i++)
     {

--- a/manage_windows.c
+++ b/manage_windows.c
@@ -131,7 +131,6 @@ rebuild_listbox(void)
 {
     vwm_t           *vwm;
     int             count;
-    int             existing;
     int             i;
     vk_widget_t     *w;
     const char      *title;
@@ -147,9 +146,7 @@ rebuild_listbox(void)
         count = vk_deck_count(vwm->deck);
     }
 
-    existing = vk_listbox_get_item_count(windows_listbox);
-    for(i = existing - 1; i >= 0; i--)
-        vk_listbox_remove_item(windows_listbox, i);
+    vk_listbox_reset(windows_listbox);
 
     if(count == 0)
     {


### PR DESCRIPTION
Four dialog rebuilds emptied their listbox with a
for(i = count-1; i >= 0; i--) vk_listbox_remove_item(lb, i) loop before repopulating.  Replace each with vk_listbox_reset(lb).

Verified in libviper vk_listbox.c that both paths free items identically -- free(item->name); free(item) -- so it is behaviour- and memory-equivalent (no leak, no double-free); items own no other pointer.  It is also a single O(n) pass instead of the loop's O(n^2) (each remove_item walks from the head to idx).  Callers repopulate and set the selection immediately, so the only state delta (reset zeroes curr_item) is irrelevant.  Drop the now-unused count/existing locals.

Sites: manage_settings, manage_hotkeys, manage_apps, manage_windows. mainmenu's remove_item is a conditional trailing-separator trim, not a full clear, and is deliberately left as-is.