### PR TITLE
refactor: extract listbox_scroll_info into manage_ui_common (S2 spike)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,6 +100,7 @@ add_executable(vwm
     manage_hotkeys.c
     manage_settings.c
     manage_windows.c
+    manage_ui_common.c
     signals.c
     strings.c
     vwm.c

--- a/manage_apps.c
+++ b/manage_apps.c
@@ -18,6 +18,7 @@
 #include "panel.h"
 #include "winman.h"
 #include "manage_apps.h"
+#include "manage_ui_common.h"
 
 #define MANAGE_APPS_HELP \
 "[Tab] cycle controls  [Up/Dn] navigate list  " \
@@ -187,22 +188,6 @@ static int  manage_apps_kmio(vk_object_t *object, int32_t keystroke);
 static void saved_popup_show(void);
 static void confirm_popup_show(void);
 static void confirm_popup_close(void);
-
-static void
-listbox_scroll_info(vk_widget_t *child,
-    int *content_h, int *content_w,
-    int *scroll_y, int *scroll_x)
-{
-    vk_listbox_t *lb = VK_LISTBOX(child);
-    int metrics_w = 0;
-
-    vk_listbox_get_metrics(lb, &metrics_w, NULL);
-
-    if(content_h) *content_h = vk_listbox_get_item_count(lb);
-    if(content_w) *content_w = metrics_w;
-    if(scroll_y) *scroll_y = vk_listbox_get_curr(lb);
-    if(scroll_x) *scroll_x = 0;
-}
 
 static int
 vterm_index_from_name(const char *name)
@@ -2080,7 +2065,7 @@ build_dialog(void)
     vk_scroller_set_scroll_source(listbox_scroller,
         VK_WIDGET(app_listbox));
     vk_scroller_set_scroll_info(listbox_scroller,
-        listbox_scroll_info);
+        vwm_listbox_scroll_info);
     vk_widget_attach_scroller(VK_WIDGET(app_listbox),
         listbox_scroller);
 

--- a/manage_hotkeys.c
+++ b/manage_hotkeys.c
@@ -17,6 +17,7 @@
 #include "winman.h"
 #include "mainmenu.h"
 #include "manage_hotkeys.h"
+#include "manage_ui_common.h"
 
 #define MANAGE_HOTKEYS_HELP \
 "[Tab] cycle controls  [Up/Dn] select hotkey  " \
@@ -226,22 +227,6 @@ lb_index_to_entry(int lb_idx)
     }
 
     return -1;
-}
-
-static void
-listbox_scroll_info(vk_widget_t *child,
-    int *content_h, int *content_w,
-    int *scroll_y, int *scroll_x)
-{
-    vk_listbox_t *lb = VK_LISTBOX(child);
-    int metrics_w = 0;
-
-    vk_listbox_get_metrics(lb, &metrics_w, NULL);
-
-    if(content_h) *content_h = vk_listbox_get_item_count(lb);
-    if(content_w) *content_w = metrics_w;
-    if(scroll_y) *scroll_y = vk_listbox_get_curr(lb);
-    if(scroll_x) *scroll_x = 0;
 }
 
 /* ── model / vwm sync ──────────────────────────────────────── */
@@ -1516,7 +1501,7 @@ build_dialog(void)
     vk_scroller_set_scroll_source(listbox_scroller,
         VK_WIDGET(hotkey_listbox));
     vk_scroller_set_scroll_info(listbox_scroller,
-        listbox_scroll_info);
+        vwm_listbox_scroll_info);
     vk_widget_attach_scroller(VK_WIDGET(hotkey_listbox),
         listbox_scroller);
 

--- a/manage_settings.c
+++ b/manage_settings.c
@@ -18,6 +18,7 @@
 #include "modules.h"
 #include "mainmenu.h"
 #include "manage_settings.h"
+#include "manage_ui_common.h"
 #include "winman.h"
 #include "bkgd.h"
 
@@ -218,22 +219,6 @@ static void rebuild_listbox(void);
 static void refresh_dialog(void);
 static void refresh_load_popup(void);
 static int  manage_settings_kmio(vk_object_t *object, int32_t keystroke);
-
-static void
-listbox_scroll_info(vk_widget_t *child,
-    int *content_h, int *content_w,
-    int *scroll_y, int *scroll_x)
-{
-    vk_listbox_t *lb = VK_LISTBOX(child);
-    int metrics_w = 0;
-
-    vk_listbox_get_metrics(lb, &metrics_w, NULL);
-
-    if(content_h) *content_h = vk_listbox_get_item_count(lb);
-    if(content_w) *content_w = metrics_w;
-    if(scroll_y) *scroll_y = vk_listbox_get_curr(lb);
-    if(scroll_x) *scroll_x = 0;
-}
 
 /* ── app options population ───────────────────────────────── */
 
@@ -2407,7 +2392,7 @@ build_dialog(void)
     vk_scroller_set_scroll_source(listbox_scroller,
         VK_WIDGET(settings_listbox));
     vk_scroller_set_scroll_info(listbox_scroller,
-        listbox_scroll_info);
+        vwm_listbox_scroll_info);
     vk_widget_attach_scroller(VK_WIDGET(settings_listbox),
         listbox_scroller);
 

--- a/manage_ui_common.c
+++ b/manage_ui_common.c
@@ -1,0 +1,21 @@
+#include <ncursesw/curses.h>
+
+#include <vdk.h>
+
+#include "manage_ui_common.h"
+
+void
+vwm_listbox_scroll_info(vk_widget_t *child,
+    int *content_h, int *content_w,
+    int *scroll_y, int *scroll_x)
+{
+    vk_listbox_t *lb = VK_LISTBOX(child);
+    int metrics_w = 0;
+
+    vk_listbox_get_metrics(lb, &metrics_w, NULL);
+
+    if(content_h) *content_h = vk_listbox_get_item_count(lb);
+    if(content_w) *content_w = metrics_w;
+    if(scroll_y) *scroll_y = vk_listbox_get_curr(lb);
+    if(scroll_x) *scroll_x = 0;
+}

--- a/manage_ui_common.h
+++ b/manage_ui_common.h
@@ -1,0 +1,17 @@
+#ifndef _VWM_MANAGE_UI_COMMON_H_
+#define _VWM_MANAGE_UI_COMMON_H_
+
+#include <vdk.h>
+
+/*
+    UI primitives shared by the Manage Settings / Hotkeys / Apps dialogs,
+    extracted from their former per-file copies (TODO S2).
+*/
+
+/* vk_scroller content/scroll-extent callback for a listbox child: reports
+   the item count as content height, the listbox width as content width,
+   and the current item as the vertical scroll position. */
+void    vwm_listbox_scroll_info(vk_widget_t *child,
+            int *content_h, int *content_w, int *scroll_y, int *scroll_x);
+
+#endif


### PR DESCRIPTION
First slice of the S2 consolidation.  The Manage Settings/Hotkeys/Apps dialogs each carried a byte-identical static listbox_scroll_info (the vk_scroller content/scroll-extent callback).  Move it to a new shared translation unit, manage_ui_common.{c,h}, as vwm_listbox_scroll_info, and point the three scroller registrations at it.

This stands up manage_ui_common and proves the mechanism (new TU + header + CMakeLists wiring + linkage) on the smallest, safest family. Net LOC is ~neutral here since the helper is tiny; the payoff lands with the larger families (warning/confirm/saved/error popups), which follow one commit at a time.