### PR TITLE
refactor: share the warning popup across the manage dialogs (S2)

### DIFF
--- a/manage_apps.c
+++ b/manage_apps.c
@@ -1376,97 +1376,10 @@ warning_popup_kmio(vk_object_t *object, int32_t keystroke)
 static void
 warning_popup_show(void)
 {
-    vwm_t       *vwm;
-    vk_box_t    *client;
-    int         scr_w, scr_h;
-    int         popup_w = 52;
-    int         popup_h = 9;
-    int         pos_x, pos_y;
-
     if(warning_popup != NULL) return;
 
-    vwm = vwm_get_instance();
-    getmaxyx(vk_screen_get_window(vwm->screen), scr_h, scr_w);
-
-    warning_popup = vk_popup_create(popup_w, popup_h,
-        VK_BORDER_SINGLE, "OK", NULL);
-    vk_popup_set_title(warning_popup, " Warning ");
-    vk_popup_set_border_colors(warning_popup, COLOR_RED, COLOR_WHITE);
-    vk_popup_set_border_attrs(warning_popup, A_NORMAL);
-    {
-        vk_box_t *bar = vk_popup_get_button_bar(warning_popup);
-        if(bar != NULL)
-        {
-            vk_widget_set_colors(VK_WIDGET(bar), COLOR_RED, COLOR_WHITE);
-            vk_widget_fill(VK_WIDGET(bar),
-                ' ' | COLOR_PAIR(vdk_color_pair(COLOR_RED, COLOR_WHITE)));
-        }
-    }
-
-    client = vk_box_create(popup_w - 2, popup_h - 5,
-        VK_BOX_VERTICAL, 4);
-    vk_box_set_homogeneous(client, true);
-    vk_widget_set_colors(VK_WIDGET(client), COLOR_RED, COLOR_WHITE);
-
-    {
-        vk_filler_t *top_pad = vk_filler_create();
-        vk_widget_set_colors(VK_WIDGET(top_pad), COLOR_RED, COLOR_WHITE);
-        vk_box_set_widget(client, 0, VK_WIDGET(top_pad));
-
-        vk_label_t *line1 = vk_label_create(popup_w - 2);
-        vk_label_set_justify(line1, VK_JUSTIFY_CENTER);
-        vk_label_set_text(line1,
-            "If the terminal becomes too small, this dialog");
-        vk_widget_set_colors(VK_WIDGET(line1), COLOR_RED, COLOR_WHITE);
-        vk_label_update(line1);
-        vk_box_set_widget(client, 1, VK_WIDGET(line1));
-
-        vk_label_t *line2 = vk_label_create(popup_w - 2);
-        vk_label_set_justify(line2, VK_JUSTIFY_CENTER);
-        vk_label_set_text(line2,
-            "will close and unsaved changes may be lost.");
-        vk_widget_set_colors(VK_WIDGET(line2), COLOR_RED, COLOR_WHITE);
-        vk_label_update(line2);
-        vk_box_set_widget(client, 2, VK_WIDGET(line2));
-
-        vk_filler_t *bot_pad = vk_filler_create();
-        vk_widget_set_colors(VK_WIDGET(bot_pad), COLOR_RED, COLOR_WHITE);
-        vk_box_set_widget(client, 3, VK_WIDGET(bot_pad));
-    }
-
-    vk_popup_set_client(warning_popup, VK_WIDGET(client));
-
-    {
-        uint32_t st = vk_widget_get_state(VK_WIDGET(client));
-        vk_widget_set_state(VK_WIDGET(client), st & ~VK_STATE_EXPAND);
-    }
-
-    vk_popup_set_colors(warning_popup, COLOR_RED, COLOR_WHITE);
+    warning_popup = vwm_warning_popup_show();
     vk_object_set_kmio(VK_OBJECT(warning_popup), warning_popup_kmio);
-
-    {
-        vk_button_t *ok_btn = vk_popup_get_button(warning_popup, 0);
-        vk_widget_set_colors(VK_WIDGET(ok_btn), COLOR_YELLOW, COLOR_WHITE);
-        vk_widget_set_attrs(VK_WIDGET(ok_btn), A_BOLD);
-        vk_button_update(ok_btn);
-    }
-
-    pos_x = (scr_w - popup_w) / 2;
-    pos_y = (scr_h - popup_h) / 2;
-    if(pos_x < 0) pos_x = 0;
-    if(pos_y < 0) pos_y = 0;
-
-    vk_widget_move(VK_WIDGET(warning_popup), pos_x, pos_y);
-
-    vk_screen_attach_widget(vwm->screen,
-        vk_screen_get_active_surface(vwm->screen),
-        VK_WIDGET(warning_popup));
-
-    vk_widget_fill(VK_WIDGET(client),
-        ' ' | COLOR_PAIR(vdk_color_pair(COLOR_RED, COLOR_WHITE)));
-    vk_box_update(client);
-    vk_popup_update(warning_popup);
-    vk_screen_refresh(vwm->screen);
 }
 
 /* ── saved popup ───────────────────────────────────────────── */

--- a/manage_hotkeys.c
+++ b/manage_hotkeys.c
@@ -640,97 +640,10 @@ warning_popup_kmio(vk_object_t *object, int32_t keystroke)
 static void
 warning_popup_show(void)
 {
-    vwm_t       *vwm;
-    vk_box_t    *client;
-    int         scr_w, scr_h;
-    int         popup_w = 52;
-    int         popup_h = 9;
-    int         pos_x, pos_y;
-
     if(warning_popup != NULL) return;
 
-    vwm = vwm_get_instance();
-    getmaxyx(vk_screen_get_window(vwm->screen), scr_h, scr_w);
-
-    warning_popup = vk_popup_create(popup_w, popup_h,
-        VK_BORDER_SINGLE, "OK", NULL);
-    vk_popup_set_title(warning_popup, " Warning ");
-    vk_popup_set_border_colors(warning_popup, COLOR_RED, COLOR_WHITE);
-    vk_popup_set_border_attrs(warning_popup, A_NORMAL);
-    {
-        vk_box_t *bar = vk_popup_get_button_bar(warning_popup);
-        if(bar != NULL)
-        {
-            vk_widget_set_colors(VK_WIDGET(bar), COLOR_RED, COLOR_WHITE);
-            vk_widget_fill(VK_WIDGET(bar),
-                ' ' | COLOR_PAIR(vdk_color_pair(COLOR_RED, COLOR_WHITE)));
-        }
-    }
-
-    client = vk_box_create(popup_w - 2, popup_h - 5,
-        VK_BOX_VERTICAL, 4);
-    vk_box_set_homogeneous(client, true);
-    vk_widget_set_colors(VK_WIDGET(client), COLOR_RED, COLOR_WHITE);
-
-    {
-        vk_filler_t *top_pad = vk_filler_create();
-        vk_widget_set_colors(VK_WIDGET(top_pad), COLOR_RED, COLOR_WHITE);
-        vk_box_set_widget(client, 0, VK_WIDGET(top_pad));
-
-        vk_label_t *line1 = vk_label_create(popup_w - 2);
-        vk_label_set_justify(line1, VK_JUSTIFY_CENTER);
-        vk_label_set_text(line1,
-            "If the terminal becomes too small, this dialog");
-        vk_widget_set_colors(VK_WIDGET(line1), COLOR_RED, COLOR_WHITE);
-        vk_label_update(line1);
-        vk_box_set_widget(client, 1, VK_WIDGET(line1));
-
-        vk_label_t *line2 = vk_label_create(popup_w - 2);
-        vk_label_set_justify(line2, VK_JUSTIFY_CENTER);
-        vk_label_set_text(line2,
-            "will close and unsaved changes may be lost.");
-        vk_widget_set_colors(VK_WIDGET(line2), COLOR_RED, COLOR_WHITE);
-        vk_label_update(line2);
-        vk_box_set_widget(client, 2, VK_WIDGET(line2));
-
-        vk_filler_t *bot_pad = vk_filler_create();
-        vk_widget_set_colors(VK_WIDGET(bot_pad), COLOR_RED, COLOR_WHITE);
-        vk_box_set_widget(client, 3, VK_WIDGET(bot_pad));
-    }
-
-    vk_popup_set_client(warning_popup, VK_WIDGET(client));
-
-    {
-        uint32_t st = vk_widget_get_state(VK_WIDGET(client));
-        vk_widget_set_state(VK_WIDGET(client), st & ~VK_STATE_EXPAND);
-    }
-
-    vk_popup_set_colors(warning_popup, COLOR_RED, COLOR_WHITE);
+    warning_popup = vwm_warning_popup_show();
     vk_object_set_kmio(VK_OBJECT(warning_popup), warning_popup_kmio);
-
-    {
-        vk_button_t *ok_btn = vk_popup_get_button(warning_popup, 0);
-        vk_widget_set_colors(VK_WIDGET(ok_btn), COLOR_YELLOW, COLOR_WHITE);
-        vk_widget_set_attrs(VK_WIDGET(ok_btn), A_BOLD);
-        vk_button_update(ok_btn);
-    }
-
-    pos_x = (scr_w - popup_w) / 2;
-    pos_y = (scr_h - popup_h) / 2;
-    if(pos_x < 0) pos_x = 0;
-    if(pos_y < 0) pos_y = 0;
-
-    vk_widget_move(VK_WIDGET(warning_popup), pos_x, pos_y);
-
-    vk_screen_attach_widget(vwm->screen,
-        vk_screen_get_active_surface(vwm->screen),
-        VK_WIDGET(warning_popup));
-
-    vk_widget_fill(VK_WIDGET(client),
-        ' ' | COLOR_PAIR(vdk_color_pair(COLOR_RED, COLOR_WHITE)));
-    vk_box_update(client);
-    vk_popup_update(warning_popup);
-    vk_screen_refresh(vwm->screen);
 }
 
 /* ── duplicate check ───────────────────────────────────────── */

--- a/manage_settings.c
+++ b/manage_settings.c
@@ -1373,97 +1373,10 @@ warning_popup_kmio(vk_object_t *object, int32_t keystroke)
 static void
 warning_popup_show(void)
 {
-    vwm_t       *vwm;
-    vk_box_t    *client;
-    int         scr_w, scr_h;
-    int         popup_w = 40;
-    int         popup_h = 9;
-    int         pos_x, pos_y;
-
     if(warning_popup != NULL) return;
 
-    vwm = vwm_get_instance();
-    getmaxyx(vk_screen_get_window(vwm->screen), scr_h, scr_w);
-
-    warning_popup = vk_popup_create(popup_w, popup_h,
-        VK_BORDER_SINGLE, "OK", NULL);
-    vk_popup_set_title(warning_popup, " Warning ");
-    vk_popup_set_border_colors(warning_popup, COLOR_RED, COLOR_WHITE);
-    vk_popup_set_border_attrs(warning_popup, A_NORMAL);
-    {
-        vk_box_t *bar = vk_popup_get_button_bar(warning_popup);
-        if(bar != NULL)
-        {
-            vk_widget_set_colors(VK_WIDGET(bar), COLOR_RED, COLOR_WHITE);
-            vk_widget_fill(VK_WIDGET(bar),
-                ' ' | COLOR_PAIR(vdk_color_pair(COLOR_RED, COLOR_WHITE)));
-        }
-    }
-
-    client = vk_box_create(popup_w - 2, popup_h - 5,
-        VK_BOX_VERTICAL, 4);
-    vk_box_set_homogeneous(client, true);
-    vk_widget_set_colors(VK_WIDGET(client), COLOR_RED, COLOR_WHITE);
-
-    {
-        vk_filler_t *top_pad = vk_filler_create();
-        vk_widget_set_colors(VK_WIDGET(top_pad), COLOR_RED, COLOR_WHITE);
-        vk_box_set_widget(client, 0, VK_WIDGET(top_pad));
-
-        vk_label_t *line1 = vk_label_create(popup_w - 2);
-        vk_label_set_justify(line1, VK_JUSTIFY_CENTER);
-        vk_label_set_text(line1,
-            "If the terminal becomes too small, this dialog");
-        vk_widget_set_colors(VK_WIDGET(line1), COLOR_RED, COLOR_WHITE);
-        vk_label_update(line1);
-        vk_box_set_widget(client, 1, VK_WIDGET(line1));
-
-        vk_label_t *line2 = vk_label_create(popup_w - 2);
-        vk_label_set_justify(line2, VK_JUSTIFY_CENTER);
-        vk_label_set_text(line2,
-            "will close and unsaved changes may be lost.");
-        vk_widget_set_colors(VK_WIDGET(line2), COLOR_RED, COLOR_WHITE);
-        vk_label_update(line2);
-        vk_box_set_widget(client, 2, VK_WIDGET(line2));
-
-        vk_filler_t *bot_pad = vk_filler_create();
-        vk_widget_set_colors(VK_WIDGET(bot_pad), COLOR_RED, COLOR_WHITE);
-        vk_box_set_widget(client, 3, VK_WIDGET(bot_pad));
-    }
-
-    vk_popup_set_client(warning_popup, VK_WIDGET(client));
-
-    {
-        uint32_t st = vk_widget_get_state(VK_WIDGET(client));
-        vk_widget_set_state(VK_WIDGET(client), st & ~VK_STATE_EXPAND);
-    }
-
-    vk_popup_set_colors(warning_popup, COLOR_RED, COLOR_WHITE);
+    warning_popup = vwm_warning_popup_show();
     vk_object_set_kmio(VK_OBJECT(warning_popup), warning_popup_kmio);
-
-    {
-        vk_button_t *ok_btn = vk_popup_get_button(warning_popup, 0);
-        vk_widget_set_colors(VK_WIDGET(ok_btn), COLOR_YELLOW, COLOR_WHITE);
-        vk_widget_set_attrs(VK_WIDGET(ok_btn), A_BOLD);
-        vk_button_update(ok_btn);
-    }
-
-    pos_x = (scr_w - popup_w) / 2;
-    pos_y = (scr_h - popup_h) / 2;
-    if(pos_x < 0) pos_x = 0;
-    if(pos_y < 0) pos_y = 0;
-
-    vk_widget_move(VK_WIDGET(warning_popup), pos_x, pos_y);
-
-    vk_screen_attach_widget(vwm->screen,
-        vk_screen_get_active_surface(vwm->screen),
-        VK_WIDGET(warning_popup));
-
-    vk_widget_fill(VK_WIDGET(client),
-        ' ' | COLOR_PAIR(vdk_color_pair(COLOR_RED, COLOR_WHITE)));
-    vk_box_update(client);
-    vk_popup_update(warning_popup);
-    vk_screen_refresh(vwm->screen);
 }
 
 /* ── saved popup ──────────────────────────────────────────── */

--- a/manage_ui_common.c
+++ b/manage_ui_common.c
@@ -2,6 +2,8 @@
 
 #include <vdk.h>
 
+#include "vwm.h"
+#include "private.h"
 #include "manage_ui_common.h"
 
 void
@@ -18,4 +20,100 @@ vwm_listbox_scroll_info(vk_widget_t *child,
     if(content_w) *content_w = metrics_w;
     if(scroll_y) *scroll_y = vk_listbox_get_curr(lb);
     if(scroll_x) *scroll_x = 0;
+}
+
+vk_popup_t *
+vwm_warning_popup_show(void)
+{
+    vwm_t       *vwm;
+    vk_box_t    *client;
+    vk_popup_t  *popup;
+    int         scr_w, scr_h;
+    int         popup_w = 52;
+    int         popup_h = 9;
+    int         pos_x, pos_y;
+
+    vwm = vwm_get_instance();
+    getmaxyx(vk_screen_get_window(vwm->screen), scr_h, scr_w);
+
+    popup = vk_popup_create(popup_w, popup_h,
+        VK_BORDER_SINGLE, "OK", NULL);
+    vk_popup_set_title(popup, " Warning ");
+    vk_popup_set_border_colors(popup, COLOR_RED, COLOR_WHITE);
+    vk_popup_set_border_attrs(popup, A_NORMAL);
+    {
+        vk_box_t *bar = vk_popup_get_button_bar(popup);
+        if(bar != NULL)
+        {
+            vk_widget_set_colors(VK_WIDGET(bar), COLOR_RED, COLOR_WHITE);
+            vk_widget_fill(VK_WIDGET(bar),
+                ' ' | COLOR_PAIR(vdk_color_pair(COLOR_RED, COLOR_WHITE)));
+        }
+    }
+
+    client = vk_box_create(popup_w - 2, popup_h - 5,
+        VK_BOX_VERTICAL, 4);
+    vk_box_set_homogeneous(client, true);
+    vk_widget_set_colors(VK_WIDGET(client), COLOR_RED, COLOR_WHITE);
+
+    {
+        vk_filler_t *top_pad = vk_filler_create();
+        vk_widget_set_colors(VK_WIDGET(top_pad), COLOR_RED, COLOR_WHITE);
+        vk_box_set_widget(client, 0, VK_WIDGET(top_pad));
+
+        vk_label_t *line1 = vk_label_create(popup_w - 2);
+        vk_label_set_justify(line1, VK_JUSTIFY_CENTER);
+        vk_label_set_text(line1,
+            "If the terminal becomes too small, this dialog");
+        vk_widget_set_colors(VK_WIDGET(line1), COLOR_RED, COLOR_WHITE);
+        vk_label_update(line1);
+        vk_box_set_widget(client, 1, VK_WIDGET(line1));
+
+        vk_label_t *line2 = vk_label_create(popup_w - 2);
+        vk_label_set_justify(line2, VK_JUSTIFY_CENTER);
+        vk_label_set_text(line2,
+            "will close and unsaved changes may be lost.");
+        vk_widget_set_colors(VK_WIDGET(line2), COLOR_RED, COLOR_WHITE);
+        vk_label_update(line2);
+        vk_box_set_widget(client, 2, VK_WIDGET(line2));
+
+        vk_filler_t *bot_pad = vk_filler_create();
+        vk_widget_set_colors(VK_WIDGET(bot_pad), COLOR_RED, COLOR_WHITE);
+        vk_box_set_widget(client, 3, VK_WIDGET(bot_pad));
+    }
+
+    vk_popup_set_client(popup, VK_WIDGET(client));
+
+    {
+        uint32_t st = vk_widget_get_state(VK_WIDGET(client));
+        vk_widget_set_state(VK_WIDGET(client), st & ~VK_STATE_EXPAND);
+    }
+
+    vk_popup_set_colors(popup, COLOR_RED, COLOR_WHITE);
+
+    {
+        vk_button_t *ok_btn = vk_popup_get_button(popup, 0);
+        vk_widget_set_colors(VK_WIDGET(ok_btn), COLOR_YELLOW, COLOR_WHITE);
+        vk_widget_set_attrs(VK_WIDGET(ok_btn), A_BOLD);
+        vk_button_update(ok_btn);
+    }
+
+    pos_x = (scr_w - popup_w) / 2;
+    pos_y = (scr_h - popup_h) / 2;
+    if(pos_x < 0) pos_x = 0;
+    if(pos_y < 0) pos_y = 0;
+
+    vk_widget_move(VK_WIDGET(popup), pos_x, pos_y);
+
+    vk_screen_attach_widget(vwm->screen,
+        vk_screen_get_active_surface(vwm->screen),
+        VK_WIDGET(popup));
+
+    vk_widget_fill(VK_WIDGET(client),
+        ' ' | COLOR_PAIR(vdk_color_pair(COLOR_RED, COLOR_WHITE)));
+    vk_box_update(client);
+    vk_popup_update(popup);
+    vk_screen_refresh(vwm->screen);
+
+    return popup;
 }

--- a/manage_ui_common.h
+++ b/manage_ui_common.h
@@ -14,4 +14,9 @@
 void    vwm_listbox_scroll_info(vk_widget_t *child,
             int *content_h, int *content_w, int *scroll_y, int *scroll_x);
 
+/* Build, center, and attach the shared "terminal becomes too small"
+   warning popup, returning it.  The caller sets its kmio handler and
+   stores the pointer.  Shared by Manage Settings / Hotkeys / Apps. */
+vk_popup_t *vwm_warning_popup_show(void);
+
 #endif


### PR DESCRIPTION
Manage Settings/Hotkeys/Apps each carried a ~85-line warning_popup_show ("terminal becomes too small" notice), identical except for width. Move the body to manage_ui_common as vwm_warning_popup_show(); each dialog's warning_popup_show is now a 4-liner that calls it and sets its own kmio.

Canonicalize the width to 52: settings used 40, which clipped the 46-char message line; hotkeys/apps already used 52.  So this also fixes that clip -- a deliberate consistency fix.

Each dialog keeps its own warning_popup pointer, close, kmio, and get_warning_popup accessor (they tie into per-dialog refresh and the classify_mouse hit-test); folding those in needs a popup-manager with a refresh callback -- a higher-risk step left for later.

net: 106 insertions, 264 deletions.