### PR TITLE
refactor: share the saved-confirmation popup across the manage dialog…

### DIFF
--- a/manage_apps.c
+++ b/manage_apps.c
@@ -1420,72 +1420,10 @@ saved_popup_kmio(vk_object_t *object, int32_t keystroke)
 static void
 saved_popup_show(void)
 {
-    vwm_t       *vwm;
-    vk_box_t    *client;
-    int         scr_w, scr_h;
-    int         popup_w = 30;
-    int         popup_h = 7;
-    int         pos_x, pos_y;
-
     if(saved_popup != NULL) return;
 
-    vwm = vwm_get_instance();
-    getmaxyx(vk_screen_get_window(vwm->screen), scr_h, scr_w);
-
-    saved_popup = vk_popup_create(popup_w, popup_h,
-        VK_BORDER_SINGLE, "OK", NULL);
-    vk_popup_set_border_colors(saved_popup, COLOR_WHITE, COLOR_BLUE);
-    vk_popup_set_border_attrs(saved_popup, A_BOLD);
-    vk_popup_set_colors(saved_popup, COLOR_WHITE, COLOR_BLUE);
-    vk_popup_set_button_colors(saved_popup, COLOR_WHITE, COLOR_BLUE);
-    vk_popup_set_button_attrs(saved_popup, A_BOLD);
-
-    client = vk_box_create(popup_w - 2, popup_h - 5,
-        VK_BOX_VERTICAL, 1);
-    vk_box_set_homogeneous(client, true);
-    vk_widget_set_colors(VK_WIDGET(client), COLOR_WHITE, COLOR_BLUE);
-
-    {
-        vk_label_t *label = vk_label_create(popup_w - 2);
-        vk_label_set_justify(label, VK_JUSTIFY_CENTER);
-        vk_label_set_text(label, "Settings saved.");
-        vk_widget_set_colors(VK_WIDGET(label), COLOR_WHITE, COLOR_BLUE);
-        vk_label_update(label);
-        vk_box_set_widget(client, 0, VK_WIDGET(label));
-    }
-
-    vk_popup_set_client(saved_popup, VK_WIDGET(client));
-
-    {
-        uint32_t st = vk_widget_get_state(VK_WIDGET(client));
-        vk_widget_set_state(VK_WIDGET(client), st & ~VK_STATE_EXPAND);
-    }
-
+    saved_popup = vwm_saved_popup_show("Apps saved.");
     vk_object_set_kmio(VK_OBJECT(saved_popup), saved_popup_kmio);
-
-    {
-        vk_button_t *ok_btn = vk_popup_get_button(saved_popup, 0);
-        vk_widget_set_colors(VK_WIDGET(ok_btn), COLOR_YELLOW, COLOR_BLUE);
-        vk_widget_set_attrs(VK_WIDGET(ok_btn), A_BOLD);
-        vk_button_update(ok_btn);
-    }
-
-    pos_x = (scr_w - popup_w) / 2;
-    pos_y = (scr_h - popup_h) / 2;
-    if(pos_x < 0) pos_x = 0;
-    if(pos_y < 0) pos_y = 0;
-
-    vk_widget_move(VK_WIDGET(saved_popup), pos_x, pos_y);
-
-    vk_screen_attach_widget(vwm->screen,
-        vk_screen_get_active_surface(vwm->screen),
-        VK_WIDGET(saved_popup));
-
-    vk_widget_fill(VK_WIDGET(client),
-        ' ' | COLOR_PAIR(vdk_color_pair(COLOR_WHITE, COLOR_BLUE)));
-    vk_box_update(client);
-    vk_popup_update(saved_popup);
-    vk_screen_refresh(vwm->screen);
 }
 
 /* ── confirm-discard popup ─────────────────────────────────── */

--- a/manage_hotkeys.c
+++ b/manage_hotkeys.c
@@ -458,79 +458,10 @@ saved_popup_kmio(vk_object_t *object, int32_t keystroke)
 static void
 saved_popup_show(void)
 {
-    vwm_t       *vwm;
-    vk_label_t  *label;
-    vk_box_t    *client;
-    int         scr_w, scr_h;
-    int         popup_w = 30;
-    int         popup_h = 7;
-    int         pos_x, pos_y;
-
     if(saved_popup != NULL) return;
 
-    vwm = vwm_get_instance();
-    getmaxyx(vk_screen_get_window(vwm->screen), scr_h, scr_w);
-
-    saved_popup = vk_popup_create(popup_w, popup_h,
-        VK_BORDER_SINGLE, "OK", NULL);
-    vk_popup_set_title(saved_popup, " Saved ");
-    vk_popup_set_border_colors(saved_popup, COLOR_WHITE, COLOR_BLUE);
-    vk_popup_set_border_attrs(saved_popup, A_BOLD);
-    {
-        vk_box_t *bar = vk_popup_get_button_bar(saved_popup);
-        if(bar != NULL)
-        {
-            vk_widget_set_colors(VK_WIDGET(bar), COLOR_WHITE, COLOR_BLUE);
-            vk_widget_fill(VK_WIDGET(bar),
-                ' ' | COLOR_PAIR(vdk_color_pair(COLOR_WHITE, COLOR_BLUE)));
-        }
-    }
-
-    client = vk_box_create(popup_w - 2, popup_h - 5,
-        VK_BOX_VERTICAL, 1);
-    vk_box_set_homogeneous(client, true);
-    vk_widget_set_colors(VK_WIDGET(client), COLOR_WHITE, COLOR_BLUE);
-
-    label = vk_label_create(popup_w - 2);
-    vk_label_set_justify(label, VK_JUSTIFY_CENTER);
-    vk_label_set_text(label, "Hotkeys saved.");
-    vk_widget_set_colors(VK_WIDGET(label), COLOR_WHITE, COLOR_BLUE);
-    vk_label_update(label);
-    vk_box_set_widget(client, 0, VK_WIDGET(label));
-
-    vk_popup_set_client(saved_popup, VK_WIDGET(client));
-
-    {
-        uint32_t st = vk_widget_get_state(VK_WIDGET(client));
-        vk_widget_set_state(VK_WIDGET(client), st & ~VK_STATE_EXPAND);
-    }
-
-    vk_popup_set_colors(saved_popup, COLOR_WHITE, COLOR_BLUE);
+    saved_popup = vwm_saved_popup_show("Hotkeys saved.");
     vk_object_set_kmio(VK_OBJECT(saved_popup), saved_popup_kmio);
-
-    {
-        vk_button_t *ok_btn = vk_popup_get_button(saved_popup, 0);
-        vk_widget_set_colors(VK_WIDGET(ok_btn), COLOR_YELLOW, COLOR_BLUE);
-        vk_widget_set_attrs(VK_WIDGET(ok_btn), A_BOLD);
-        vk_button_update(ok_btn);
-    }
-
-    pos_x = (scr_w - popup_w) / 2;
-    pos_y = (scr_h - popup_h) / 2;
-    if(pos_x < 0) pos_x = 0;
-    if(pos_y < 0) pos_y = 0;
-
-    vk_widget_move(VK_WIDGET(saved_popup), pos_x, pos_y);
-
-    vk_screen_attach_widget(vwm->screen,
-        vk_screen_get_active_surface(vwm->screen),
-        VK_WIDGET(saved_popup));
-
-    vk_widget_fill(VK_WIDGET(client),
-        ' ' | COLOR_PAIR(vdk_color_pair(COLOR_WHITE, COLOR_BLUE)));
-    vk_box_update(client);
-    vk_popup_update(saved_popup);
-    vk_screen_refresh(vwm->screen);
 }
 
 /* ── warning popup ─────────────────────────────────────────── */

--- a/manage_settings.c
+++ b/manage_settings.c
@@ -1348,72 +1348,10 @@ saved_popup_kmio(vk_object_t *object, int32_t keystroke)
 static void
 saved_popup_show(void)
 {
-    vwm_t       *vwm;
-    vk_box_t    *client;
-    int         scr_w, scr_h;
-    int         popup_w = 30;
-    int         popup_h = 7;
-    int         pos_x, pos_y;
-
     if(saved_popup != NULL) return;
 
-    vwm = vwm_get_instance();
-    getmaxyx(vk_screen_get_window(vwm->screen), scr_h, scr_w);
-
-    saved_popup = vk_popup_create(popup_w, popup_h,
-        VK_BORDER_SINGLE, "OK", NULL);
-    vk_popup_set_border_colors(saved_popup, COLOR_WHITE, COLOR_BLUE);
-    vk_popup_set_border_attrs(saved_popup, A_BOLD);
-    vk_popup_set_colors(saved_popup, COLOR_WHITE, COLOR_BLUE);
-    vk_popup_set_button_colors(saved_popup, COLOR_WHITE, COLOR_BLUE);
-    vk_popup_set_button_attrs(saved_popup, A_BOLD);
-
-    client = vk_box_create(popup_w - 2, popup_h - 5,
-        VK_BOX_VERTICAL, 1);
-    vk_box_set_homogeneous(client, true);
-    vk_widget_set_colors(VK_WIDGET(client), COLOR_WHITE, COLOR_BLUE);
-
-    {
-        vk_label_t *label = vk_label_create(popup_w - 2);
-        vk_label_set_justify(label, VK_JUSTIFY_CENTER);
-        vk_label_set_text(label, "Settings saved.");
-        vk_widget_set_colors(VK_WIDGET(label), COLOR_WHITE, COLOR_BLUE);
-        vk_label_update(label);
-        vk_box_set_widget(client, 0, VK_WIDGET(label));
-    }
-
-    vk_popup_set_client(saved_popup, VK_WIDGET(client));
-
-    {
-        uint32_t st = vk_widget_get_state(VK_WIDGET(client));
-        vk_widget_set_state(VK_WIDGET(client), st & ~VK_STATE_EXPAND);
-    }
-
+    saved_popup = vwm_saved_popup_show("Settings saved.");
     vk_object_set_kmio(VK_OBJECT(saved_popup), saved_popup_kmio);
-
-    {
-        vk_button_t *ok_btn = vk_popup_get_button(saved_popup, 0);
-        vk_widget_set_colors(VK_WIDGET(ok_btn), COLOR_YELLOW, COLOR_BLUE);
-        vk_widget_set_attrs(VK_WIDGET(ok_btn), A_BOLD);
-        vk_button_update(ok_btn);
-    }
-
-    pos_x = (scr_w - popup_w) / 2;
-    pos_y = (scr_h - popup_h) / 2;
-    if(pos_x < 0) pos_x = 0;
-    if(pos_y < 0) pos_y = 0;
-
-    vk_widget_move(VK_WIDGET(saved_popup), pos_x, pos_y);
-
-    vk_screen_attach_widget(vwm->screen,
-        vk_screen_get_active_surface(vwm->screen),
-        VK_WIDGET(saved_popup));
-
-    vk_widget_fill(VK_WIDGET(client),
-        ' ' | COLOR_PAIR(vdk_color_pair(COLOR_WHITE, COLOR_BLUE)));
-    vk_box_update(client);
-    vk_popup_update(saved_popup);
-    vk_screen_refresh(vwm->screen);
 }
 
 /* ── confirm-discard popup ────────────────────────────────── */

--- a/manage_ui_common.c
+++ b/manage_ui_common.c
@@ -119,6 +119,84 @@ vwm_warning_popup_show(void)
 }
 
 vk_popup_t *
+vwm_saved_popup_show(const char *msg)
+{
+    vwm_t       *vwm;
+    vk_label_t  *label;
+    vk_box_t    *client;
+    int         scr_w, scr_h;
+    int         popup_w = 30;
+    int         popup_h = 7;
+    int         pos_x, pos_y;
+    vk_popup_t  *popup;
+
+    vwm = vwm_get_instance();
+    getmaxyx(vk_screen_get_window(vwm->screen), scr_h, scr_w);
+
+    popup = vk_popup_create(popup_w, popup_h,
+        VK_BORDER_SINGLE, "OK", NULL);
+    vk_popup_set_title(popup, " Saved ");
+    vk_popup_set_border_colors(popup, COLOR_WHITE, COLOR_BLUE);
+    vk_popup_set_border_attrs(popup, A_BOLD);
+    {
+        vk_box_t *bar = vk_popup_get_button_bar(popup);
+        if(bar != NULL)
+        {
+            vk_widget_set_colors(VK_WIDGET(bar), COLOR_WHITE, COLOR_BLUE);
+            vk_widget_fill(VK_WIDGET(bar),
+                ' ' | COLOR_PAIR(vdk_color_pair(COLOR_WHITE, COLOR_BLUE)));
+        }
+    }
+
+    client = vk_box_create(popup_w - 2, popup_h - 5,
+        VK_BOX_VERTICAL, 1);
+    vk_box_set_homogeneous(client, true);
+    vk_widget_set_colors(VK_WIDGET(client), COLOR_WHITE, COLOR_BLUE);
+
+    label = vk_label_create(popup_w - 2);
+    vk_label_set_justify(label, VK_JUSTIFY_CENTER);
+    vk_label_set_text(label, msg);
+    vk_widget_set_colors(VK_WIDGET(label), COLOR_WHITE, COLOR_BLUE);
+    vk_label_update(label);
+    vk_box_set_widget(client, 0, VK_WIDGET(label));
+
+    vk_popup_set_client(popup, VK_WIDGET(client));
+
+    {
+        uint32_t st = vk_widget_get_state(VK_WIDGET(client));
+        vk_widget_set_state(VK_WIDGET(client), st & ~VK_STATE_EXPAND);
+    }
+
+    vk_popup_set_colors(popup, COLOR_WHITE, COLOR_BLUE);
+
+    {
+        vk_button_t *ok_btn = vk_popup_get_button(popup, 0);
+        vk_widget_set_colors(VK_WIDGET(ok_btn), COLOR_YELLOW, COLOR_BLUE);
+        vk_widget_set_attrs(VK_WIDGET(ok_btn), A_BOLD);
+        vk_button_update(ok_btn);
+    }
+
+    pos_x = (scr_w - popup_w) / 2;
+    pos_y = (scr_h - popup_h) / 2;
+    if(pos_x < 0) pos_x = 0;
+    if(pos_y < 0) pos_y = 0;
+
+    vk_widget_move(VK_WIDGET(popup), pos_x, pos_y);
+
+    vk_screen_attach_widget(vwm->screen,
+        vk_screen_get_active_surface(vwm->screen),
+        VK_WIDGET(popup));
+
+    vk_widget_fill(VK_WIDGET(client),
+        ' ' | COLOR_PAIR(vdk_color_pair(COLOR_WHITE, COLOR_BLUE)));
+    vk_box_update(client);
+    vk_popup_update(popup);
+    vk_screen_refresh(vwm->screen);
+
+    return popup;
+}
+
+vk_popup_t *
 vwm_error_popup_show(const char *msg, int popup_w, int popup_h)
 {
     vwm_t       *vwm;

--- a/manage_ui_common.h
+++ b/manage_ui_common.h
@@ -24,4 +24,9 @@ vk_popup_t *vwm_warning_popup_show(void);
    kmio handler and stores the pointer.  Shared by Settings / Hotkeys. */
 vk_popup_t *vwm_error_popup_show(const char *msg, int popup_w, int popup_h);
 
+/* Build, center, and attach the shared white-on-blue " Saved "
+   confirmation popup showing `msg`.  The caller sets its kmio handler
+   and stores the pointer.  Shared by Settings / Hotkeys / Apps. */
+vk_popup_t *vwm_saved_popup_show(const char *msg);
+
 #endif


### PR DESCRIPTION
…s (S2)

Settings, Hotkeys and Apps each carried a ~70-line saved_popup_show. Move the body to manage_ui_common as vwm_saved_popup_show(msg); each dialog's saved_popup_show is now a 4-liner that calls it (passing its own message) and sets its own kmio.

The three copies had drifted: Settings and Apps were title-less and coloured the button bar via set_button_colors, while Hotkeys carried a " Saved " title and the button-bar-fill style used by the Warning and Error popups.  Canonicalise on the titled / bar-fill version so all three match the other popups (Settings and Apps now show a " Saved " header; the bar-colour change is visually identical).

Also fix an apparent copy-paste bug: the Manage Apps popup read "Settings saved." -- it now reads "Apps saved.".