### PR TITLE
fix: Manage Apps Close now prompts on an uncommitted dropdown change

### DIFF
--- a/manage_apps.c
+++ b/manage_apps.c
@@ -1326,10 +1326,23 @@ on_load(void)
     load_popup_open();
 }
 
+static bool
+has_changes(void)
+{
+    /* Flush a pending dropdown edit (category/terminal/visibility) into
+       the model so it counts -- commit_dropdowns_to_entry only sets the
+       dirty flag when a field actually changed.  on_save flushes the
+       same way before saving; without this, Close skips the unsaved-
+       changes prompt for a dropdown change that was never committed. */
+    commit_dropdowns_to_entry(model->selected);
+
+    return model->dirty;
+}
+
 static void
 on_cancel(void)
 {
-    if(model->dirty)
+    if(has_changes())
     {
         confirm_popup_show();
         return;


### PR DESCRIPTION
Changing an app's Category (or Terminal / Visibility) only updates the dropdown widget; the model -- and its dirty flag -- isn't touched until commit_dropdowns_to_entry() runs.  on_save flushes the dropdowns before saving, but on_cancel checked model->dirty without flushing, so a Category change followed by Close slipped past the unsaved-changes prompt and the edit was silently discarded.

Wrap the check in a has_changes() predicate that flushes the pending dropdown edit first, then tests dirty (commit only flags a real change, so no false prompts).  on_cancel now reads `if(has_changes())`, matching Manage Hotkeys.  Pre-existing since the dropdown editing landed; not related to the manage_ui_common consolidation.