### PR TITLE
refactor: share the discard-confirm popup construction across the dia…

### DIFF
--- a/manage_apps.c
+++ b/manage_apps.c
@@ -1525,112 +1525,11 @@ confirm_popup_kmio(vk_object_t *object, int32_t keystroke)
 static void
 confirm_popup_show(void)
 {
-    vwm_t       *vwm;
-    vk_box_t    *client;
-    int         scr_w, scr_h;
-    int         popup_w = 40;
-    int         popup_h = 9;
-    int         pos_x, pos_y;
-
     if(confirm_popup != NULL) return;
 
-    vwm = vwm_get_instance();
-    getmaxyx(vk_screen_get_window(vwm->screen), scr_h, scr_w);
-
-    confirm_popup = vk_popup_create(popup_w, popup_h,
-        VK_BORDER_SINGLE, "Discard", "Cancel", NULL);
-    vk_popup_set_title(confirm_popup, " Confirm ");
-    vk_popup_set_border_colors(confirm_popup, COLOR_RED, COLOR_WHITE);
-    vk_popup_set_border_attrs(confirm_popup, A_NORMAL);
-    vk_popup_set_colors(confirm_popup, COLOR_RED, COLOR_WHITE);
-    {
-        vk_box_t *bar = vk_popup_get_button_bar(confirm_popup);
-        if(bar != NULL)
-        {
-            vk_widget_set_colors(VK_WIDGET(bar), COLOR_RED, COLOR_WHITE);
-            vk_widget_fill(VK_WIDGET(bar),
-                ' ' | COLOR_PAIR(vdk_color_pair(COLOR_RED, COLOR_WHITE)));
-        }
-    }
-
-    client = vk_box_create(popup_w - 2, popup_h - 5,
-        VK_BOX_VERTICAL, 4);
-    vk_box_set_homogeneous(client, true);
-    vk_widget_set_colors(VK_WIDGET(client), COLOR_RED, COLOR_WHITE);
-
-    {
-        vk_filler_t *top_pad = vk_filler_create();
-        vk_widget_set_colors(VK_WIDGET(top_pad), COLOR_RED, COLOR_WHITE);
-        vk_box_set_widget(client, 0, VK_WIDGET(top_pad));
-
-        vk_label_t *line1 = vk_label_create(popup_w - 2);
-        vk_label_set_justify(line1, VK_JUSTIFY_CENTER);
-        vk_label_set_text(line1, "You have unsaved changes.");
-        vk_widget_set_colors(VK_WIDGET(line1), COLOR_RED, COLOR_WHITE);
-        vk_label_update(line1);
-        vk_box_set_widget(client, 1, VK_WIDGET(line1));
-
-        vk_label_t *line2 = vk_label_create(popup_w - 2);
-        vk_label_set_justify(line2, VK_JUSTIFY_CENTER);
-        vk_label_set_text(line2, "Discard changes and close?");
-        vk_widget_set_colors(VK_WIDGET(line2), COLOR_RED, COLOR_WHITE);
-        vk_label_update(line2);
-        vk_box_set_widget(client, 2, VK_WIDGET(line2));
-
-        vk_filler_t *bot_pad = vk_filler_create();
-        vk_widget_set_colors(VK_WIDGET(bot_pad), COLOR_RED, COLOR_WHITE);
-        vk_box_set_widget(client, 3, VK_WIDGET(bot_pad));
-    }
-
-    vk_popup_set_client(confirm_popup, VK_WIDGET(client));
-
-    {
-        uint32_t st = vk_widget_get_state(VK_WIDGET(client));
-        vk_widget_set_state(VK_WIDGET(client), st & ~VK_STATE_EXPAND);
-    }
-
+    confirm_popup = vwm_confirm_popup_show();
     vk_object_set_kmio(VK_OBJECT(confirm_popup), confirm_popup_kmio);
-
     confirm_active_btn = 0;
-
-    {
-        int count = vk_popup_get_button_count(confirm_popup);
-        for(int i = 0; i < count; i++)
-        {
-            vk_button_t *btn = vk_popup_get_button(confirm_popup, i);
-
-            if(i == confirm_active_btn)
-            {
-                vk_widget_set_colors(VK_WIDGET(btn),
-                    COLOR_YELLOW, COLOR_WHITE);
-            }
-            else
-            {
-                vk_widget_set_colors(VK_WIDGET(btn),
-                    COLOR_BLACK, COLOR_WHITE);
-            }
-
-            vk_widget_set_attrs(VK_WIDGET(btn), A_BOLD);
-            vk_button_update(btn);
-        }
-    }
-
-    pos_x = (scr_w - popup_w) / 2;
-    pos_y = (scr_h - popup_h) / 2;
-    if(pos_x < 0) pos_x = 0;
-    if(pos_y < 0) pos_y = 0;
-
-    vk_widget_move(VK_WIDGET(confirm_popup), pos_x, pos_y);
-
-    vk_screen_attach_widget(vwm->screen,
-        vk_screen_get_active_surface(vwm->screen),
-        VK_WIDGET(confirm_popup));
-
-    vk_widget_fill(VK_WIDGET(client),
-        ' ' | COLOR_PAIR(vdk_color_pair(COLOR_RED, COLOR_WHITE)));
-    vk_box_update(client);
-    vk_popup_update(confirm_popup);
-    vk_screen_refresh(vwm->screen);
 }
 
 /* ── keyboard handlers ──────────────────────────────────────── */

--- a/manage_hotkeys.c
+++ b/manage_hotkeys.c
@@ -642,111 +642,11 @@ confirm_popup_kmio(vk_object_t *object, int32_t keystroke)
 static void
 confirm_popup_show(void)
 {
-    vwm_t       *vwm;
-    vk_box_t    *client;
-    int         scr_w, scr_h;
-    int         popup_w = 40;
-    int         popup_h = 9;
-    int         pos_x, pos_y;
-
     if(confirm_popup != NULL) return;
 
-    vwm = vwm_get_instance();
-    getmaxyx(vk_screen_get_window(vwm->screen), scr_h, scr_w);
-
-    confirm_popup = vk_popup_create(popup_w, popup_h,
-        VK_BORDER_SINGLE, "Discard", "Cancel", NULL);
-    vk_popup_set_title(confirm_popup, " Confirm ");
-    vk_popup_set_border_colors(confirm_popup, COLOR_RED, COLOR_WHITE);
-    vk_popup_set_border_attrs(confirm_popup, A_NORMAL);
-    {
-        vk_box_t *bar = vk_popup_get_button_bar(confirm_popup);
-        if(bar != NULL)
-        {
-            vk_widget_set_colors(VK_WIDGET(bar), COLOR_RED, COLOR_WHITE);
-            vk_widget_fill(VK_WIDGET(bar),
-                ' ' | COLOR_PAIR(vdk_color_pair(COLOR_RED, COLOR_WHITE)));
-        }
-    }
-
-    client = vk_box_create(popup_w - 2, popup_h - 5,
-        VK_BOX_VERTICAL, 4);
-    vk_box_set_homogeneous(client, true);
-    vk_widget_set_colors(VK_WIDGET(client), COLOR_RED, COLOR_WHITE);
-
-    {
-        vk_filler_t *top_pad = vk_filler_create();
-        vk_widget_set_colors(VK_WIDGET(top_pad), COLOR_RED, COLOR_WHITE);
-        vk_box_set_widget(client, 0, VK_WIDGET(top_pad));
-
-        vk_label_t *line1 = vk_label_create(popup_w - 2);
-        vk_label_set_justify(line1, VK_JUSTIFY_CENTER);
-        vk_label_set_text(line1, "You have unsaved changes.");
-        vk_widget_set_colors(VK_WIDGET(line1), COLOR_RED, COLOR_WHITE);
-        vk_label_update(line1);
-        vk_box_set_widget(client, 1, VK_WIDGET(line1));
-
-        vk_label_t *line2 = vk_label_create(popup_w - 2);
-        vk_label_set_justify(line2, VK_JUSTIFY_CENTER);
-        vk_label_set_text(line2, "Discard changes and close?");
-        vk_widget_set_colors(VK_WIDGET(line2), COLOR_RED, COLOR_WHITE);
-        vk_label_update(line2);
-        vk_box_set_widget(client, 2, VK_WIDGET(line2));
-
-        vk_filler_t *bot_pad = vk_filler_create();
-        vk_widget_set_colors(VK_WIDGET(bot_pad), COLOR_RED, COLOR_WHITE);
-        vk_box_set_widget(client, 3, VK_WIDGET(bot_pad));
-    }
-
-    vk_popup_set_client(confirm_popup, VK_WIDGET(client));
-
-    {
-        uint32_t st = vk_widget_get_state(VK_WIDGET(client));
-        vk_widget_set_state(VK_WIDGET(client), st & ~VK_STATE_EXPAND);
-    }
-
-    vk_popup_set_colors(confirm_popup, COLOR_RED, COLOR_WHITE);
+    confirm_popup = vwm_confirm_popup_show();
     vk_object_set_kmio(VK_OBJECT(confirm_popup), confirm_popup_kmio);
-
     confirm_active_btn = 0;
-
-    {
-        int count = vk_popup_get_button_count(confirm_popup);
-        for(int i = 0; i < count; i++)
-        {
-            vk_button_t *btn = vk_popup_get_button(confirm_popup, i);
-            if(i == 0)
-            {
-                vk_widget_set_colors(VK_WIDGET(btn),
-                    COLOR_YELLOW, COLOR_WHITE);
-                vk_widget_set_attrs(VK_WIDGET(btn), A_BOLD);
-            }
-            else
-            {
-                vk_widget_set_colors(VK_WIDGET(btn),
-                    COLOR_BLACK, COLOR_WHITE);
-                vk_widget_set_attrs(VK_WIDGET(btn), A_BOLD);
-            }
-            vk_button_update(btn);
-        }
-    }
-
-    pos_x = (scr_w - popup_w) / 2;
-    pos_y = (scr_h - popup_h) / 2;
-    if(pos_x < 0) pos_x = 0;
-    if(pos_y < 0) pos_y = 0;
-
-    vk_widget_move(VK_WIDGET(confirm_popup), pos_x, pos_y);
-
-    vk_screen_attach_widget(vwm->screen,
-        vk_screen_get_active_surface(vwm->screen),
-        VK_WIDGET(confirm_popup));
-
-    vk_widget_fill(VK_WIDGET(client),
-        ' ' | COLOR_PAIR(vdk_color_pair(COLOR_RED, COLOR_WHITE)));
-    vk_box_update(client);
-    vk_popup_update(confirm_popup);
-    vk_screen_refresh(vwm->screen);
 }
 
 /* ── load popup ────────────────────────────────────────────── */

--- a/manage_settings.c
+++ b/manage_settings.c
@@ -1440,112 +1440,11 @@ confirm_popup_kmio(vk_object_t *object, int32_t keystroke)
 static void
 confirm_popup_show(void)
 {
-    vwm_t       *vwm;
-    vk_box_t    *client;
-    int         scr_w, scr_h;
-    int         popup_w = 40;
-    int         popup_h = 9;
-    int         pos_x, pos_y;
-
     if(confirm_popup != NULL) return;
 
-    vwm = vwm_get_instance();
-    getmaxyx(vk_screen_get_window(vwm->screen), scr_h, scr_w);
-
-    confirm_popup = vk_popup_create(popup_w, popup_h,
-        VK_BORDER_SINGLE, "Discard", "Cancel", NULL);
-    vk_popup_set_title(confirm_popup, " Confirm ");
-    vk_popup_set_border_colors(confirm_popup, COLOR_RED, COLOR_WHITE);
-    vk_popup_set_border_attrs(confirm_popup, A_NORMAL);
-    vk_popup_set_colors(confirm_popup, COLOR_RED, COLOR_WHITE);
-    {
-        vk_box_t *bar = vk_popup_get_button_bar(confirm_popup);
-        if(bar != NULL)
-        {
-            vk_widget_set_colors(VK_WIDGET(bar), COLOR_RED, COLOR_WHITE);
-            vk_widget_fill(VK_WIDGET(bar),
-                ' ' | COLOR_PAIR(vdk_color_pair(COLOR_RED, COLOR_WHITE)));
-        }
-    }
-
-    client = vk_box_create(popup_w - 2, popup_h - 5,
-        VK_BOX_VERTICAL, 4);
-    vk_box_set_homogeneous(client, true);
-    vk_widget_set_colors(VK_WIDGET(client), COLOR_RED, COLOR_WHITE);
-
-    {
-        vk_filler_t *top_pad = vk_filler_create();
-        vk_widget_set_colors(VK_WIDGET(top_pad), COLOR_RED, COLOR_WHITE);
-        vk_box_set_widget(client, 0, VK_WIDGET(top_pad));
-
-        vk_label_t *line1 = vk_label_create(popup_w - 2);
-        vk_label_set_justify(line1, VK_JUSTIFY_CENTER);
-        vk_label_set_text(line1, "You have unsaved changes.");
-        vk_widget_set_colors(VK_WIDGET(line1), COLOR_RED, COLOR_WHITE);
-        vk_label_update(line1);
-        vk_box_set_widget(client, 1, VK_WIDGET(line1));
-
-        vk_label_t *line2 = vk_label_create(popup_w - 2);
-        vk_label_set_justify(line2, VK_JUSTIFY_CENTER);
-        vk_label_set_text(line2, "Discard changes and close?");
-        vk_widget_set_colors(VK_WIDGET(line2), COLOR_RED, COLOR_WHITE);
-        vk_label_update(line2);
-        vk_box_set_widget(client, 2, VK_WIDGET(line2));
-
-        vk_filler_t *bot_pad = vk_filler_create();
-        vk_widget_set_colors(VK_WIDGET(bot_pad), COLOR_RED, COLOR_WHITE);
-        vk_box_set_widget(client, 3, VK_WIDGET(bot_pad));
-    }
-
-    vk_popup_set_client(confirm_popup, VK_WIDGET(client));
-
-    {
-        uint32_t st = vk_widget_get_state(VK_WIDGET(client));
-        vk_widget_set_state(VK_WIDGET(client), st & ~VK_STATE_EXPAND);
-    }
-
+    confirm_popup = vwm_confirm_popup_show();
     vk_object_set_kmio(VK_OBJECT(confirm_popup), confirm_popup_kmio);
-
     confirm_active_btn = 0;
-
-    {
-        int count = vk_popup_get_button_count(confirm_popup);
-        for(int i = 0; i < count; i++)
-        {
-            vk_button_t *btn = vk_popup_get_button(confirm_popup, i);
-
-            if(i == confirm_active_btn)
-            {
-                vk_widget_set_colors(VK_WIDGET(btn),
-                    COLOR_YELLOW, COLOR_WHITE);
-            }
-            else
-            {
-                vk_widget_set_colors(VK_WIDGET(btn),
-                    COLOR_BLACK, COLOR_WHITE);
-            }
-
-            vk_widget_set_attrs(VK_WIDGET(btn), A_BOLD);
-            vk_button_update(btn);
-        }
-    }
-
-    pos_x = (scr_w - popup_w) / 2;
-    pos_y = (scr_h - popup_h) / 2;
-    if(pos_x < 0) pos_x = 0;
-    if(pos_y < 0) pos_y = 0;
-
-    vk_widget_move(VK_WIDGET(confirm_popup), pos_x, pos_y);
-
-    vk_screen_attach_widget(vwm->screen,
-        vk_screen_get_active_surface(vwm->screen),
-        VK_WIDGET(confirm_popup));
-
-    vk_widget_fill(VK_WIDGET(client),
-        ' ' | COLOR_PAIR(vdk_color_pair(COLOR_RED, COLOR_WHITE)));
-    vk_box_update(client);
-    vk_popup_update(confirm_popup);
-    vk_screen_refresh(vwm->screen);
 }
 
 /* ── save-confirm popup ──────────────────────────────────── */

--- a/manage_ui_common.c
+++ b/manage_ui_common.c
@@ -197,6 +197,114 @@ vwm_saved_popup_show(const char *msg)
 }
 
 vk_popup_t *
+vwm_confirm_popup_show(void)
+{
+    vwm_t       *vwm;
+    vk_box_t    *client;
+    int         scr_w, scr_h;
+    int         popup_w = 40;
+    int         popup_h = 9;
+    int         pos_x, pos_y;
+    vk_popup_t  *popup;
+
+    vwm = vwm_get_instance();
+    getmaxyx(vk_screen_get_window(vwm->screen), scr_h, scr_w);
+
+    popup = vk_popup_create(popup_w, popup_h,
+        VK_BORDER_SINGLE, "Discard", "Cancel", NULL);
+    vk_popup_set_title(popup, " Confirm ");
+    vk_popup_set_border_colors(popup, COLOR_RED, COLOR_WHITE);
+    vk_popup_set_border_attrs(popup, A_NORMAL);
+    vk_popup_set_colors(popup, COLOR_RED, COLOR_WHITE);
+    {
+        vk_box_t *bar = vk_popup_get_button_bar(popup);
+        if(bar != NULL)
+        {
+            vk_widget_set_colors(VK_WIDGET(bar), COLOR_RED, COLOR_WHITE);
+            vk_widget_fill(VK_WIDGET(bar),
+                ' ' | COLOR_PAIR(vdk_color_pair(COLOR_RED, COLOR_WHITE)));
+        }
+    }
+
+    client = vk_box_create(popup_w - 2, popup_h - 5,
+        VK_BOX_VERTICAL, 4);
+    vk_box_set_homogeneous(client, true);
+    vk_widget_set_colors(VK_WIDGET(client), COLOR_RED, COLOR_WHITE);
+
+    {
+        vk_filler_t *top_pad = vk_filler_create();
+        vk_widget_set_colors(VK_WIDGET(top_pad), COLOR_RED, COLOR_WHITE);
+        vk_box_set_widget(client, 0, VK_WIDGET(top_pad));
+
+        vk_label_t *line1 = vk_label_create(popup_w - 2);
+        vk_label_set_justify(line1, VK_JUSTIFY_CENTER);
+        vk_label_set_text(line1, "You have unsaved changes.");
+        vk_widget_set_colors(VK_WIDGET(line1), COLOR_RED, COLOR_WHITE);
+        vk_label_update(line1);
+        vk_box_set_widget(client, 1, VK_WIDGET(line1));
+
+        vk_label_t *line2 = vk_label_create(popup_w - 2);
+        vk_label_set_justify(line2, VK_JUSTIFY_CENTER);
+        vk_label_set_text(line2, "Discard changes and close?");
+        vk_widget_set_colors(VK_WIDGET(line2), COLOR_RED, COLOR_WHITE);
+        vk_label_update(line2);
+        vk_box_set_widget(client, 2, VK_WIDGET(line2));
+
+        vk_filler_t *bot_pad = vk_filler_create();
+        vk_widget_set_colors(VK_WIDGET(bot_pad), COLOR_RED, COLOR_WHITE);
+        vk_box_set_widget(client, 3, VK_WIDGET(bot_pad));
+    }
+
+    vk_popup_set_client(popup, VK_WIDGET(client));
+
+    {
+        uint32_t st = vk_widget_get_state(VK_WIDGET(client));
+        vk_widget_set_state(VK_WIDGET(client), st & ~VK_STATE_EXPAND);
+    }
+
+    {
+        int count = vk_popup_get_button_count(popup);
+        for(int i = 0; i < count; i++)
+        {
+            vk_button_t *btn = vk_popup_get_button(popup, i);
+
+            if(i == 0)
+            {
+                vk_widget_set_colors(VK_WIDGET(btn),
+                    COLOR_YELLOW, COLOR_WHITE);
+            }
+            else
+            {
+                vk_widget_set_colors(VK_WIDGET(btn),
+                    COLOR_BLACK, COLOR_WHITE);
+            }
+
+            vk_widget_set_attrs(VK_WIDGET(btn), A_BOLD);
+            vk_button_update(btn);
+        }
+    }
+
+    pos_x = (scr_w - popup_w) / 2;
+    pos_y = (scr_h - popup_h) / 2;
+    if(pos_x < 0) pos_x = 0;
+    if(pos_y < 0) pos_y = 0;
+
+    vk_widget_move(VK_WIDGET(popup), pos_x, pos_y);
+
+    vk_screen_attach_widget(vwm->screen,
+        vk_screen_get_active_surface(vwm->screen),
+        VK_WIDGET(popup));
+
+    vk_widget_fill(VK_WIDGET(client),
+        ' ' | COLOR_PAIR(vdk_color_pair(COLOR_RED, COLOR_WHITE)));
+    vk_box_update(client);
+    vk_popup_update(popup);
+    vk_screen_refresh(vwm->screen);
+
+    return popup;
+}
+
+vk_popup_t *
 vwm_error_popup_show(const char *msg, int popup_w, int popup_h)
 {
     vwm_t       *vwm;

--- a/manage_ui_common.h
+++ b/manage_ui_common.h
@@ -29,4 +29,11 @@ vk_popup_t *vwm_error_popup_show(const char *msg, int popup_w, int popup_h);
    and stores the pointer.  Shared by Settings / Hotkeys / Apps. */
 vk_popup_t *vwm_saved_popup_show(const char *msg);
 
+/* Build, center, and attach the shared red-on-white " Confirm " discard
+   dialog ("You have unsaved changes." / "Discard changes and close?")
+   with Discard / Cancel buttons (button 0 active), returning it.  The
+   caller sets its kmio handler, stores the pointer, and resets its own
+   active-button index.  Shared by Settings / Hotkeys / Apps. */
+vk_popup_t *vwm_confirm_popup_show(void);
+
 #endif


### PR DESCRIPTION
…logs (S2)

Settings, Hotkeys and Apps each built the identical " Confirm " / "You have unsaved changes." discard dialog (40x9, Discard/Cancel, red-on-white) in a ~110-line confirm_popup_show.  Move the construction to manage_ui_common as vwm_confirm_popup_show(), returning the popup with button 0 active; each dialog's confirm_popup_show is now a 4-liner that calls it, sets its own kmio, and resets its active-button index.

The interactive parts stay per-dialog on purpose: the kmio (whose only real difference is the vwm_manage_<x>_close() it calls on Discard) and confirm_popup_close() both reference the per-dialog confirm_popup pointer that the dialogs' mouse/keyboard routing is woven around, and the close action is dialog-specific.  Only the pure construction is shared, so the discard behaviour is byte-for-byte unchanged.