### PR TITLE
refactor: share the file-load popup construction across the dialogs (S2)

### DIFF
--- a/manage_apps.c
+++ b/manage_apps.c
@@ -154,9 +154,6 @@ static int             edit_active_btn = EDIT_BTN_OK;
 static bool            edit_is_add_mode = false;
 static vk_dropdown_t   *active_dropdown = NULL;
 
-#define LOAD_WIDTH          50
-#define LOAD_HEIGHT         20
-
 static struct timespec      list_last_click_time;
 static int                 list_last_click_item = -1;
 
@@ -1081,42 +1078,7 @@ load_popup_ok(void)
 static void
 update_load_focus(void)
 {
-    vk_widget_t *bar_w;
-    vk_widget_t *ok = NULL;
-    vk_widget_t *cancel = NULL;
-
-    if(load_filedialog == NULL) return;
-
-    /* swap the file_list highlight: BLACK/RED when browser focused,
-       BLACK/WHITE when focus has moved to the buttons */
-    vk_listbox_set_focused(vk_filedialog_get_file_list(load_filedialog),
-        load_focus == LF_FILEDIALOG);
-
-    bar_w = vk_box_get_widget(VK_BOX(load_filedialog), 2);
-    if(bar_w != NULL)
-    {
-        ok = vk_box_get_widget(VK_BOX(bar_w), 0);
-        cancel = vk_box_get_widget(VK_BOX(bar_w), 1);
-    }
-
-    if(ok != NULL)
-    {
-        vk_button_release(VK_BUTTON(ok));
-        vk_widget_set_colors(ok,
-            (load_focus == LF_OK) ? COLOR_YELLOW : COLOR_WHITE, COLOR_BLUE);
-        vk_widget_set_attrs(ok, A_BOLD);
-        vk_button_update(VK_BUTTON(ok));
-    }
-
-    if(cancel != NULL)
-    {
-        vk_button_release(VK_BUTTON(cancel));
-        vk_widget_set_colors(cancel,
-            (load_focus == LF_CANCEL) ? COLOR_YELLOW : COLOR_WHITE,
-            COLOR_BLUE);
-        vk_widget_set_attrs(cancel, A_BOLD);
-        vk_button_update(VK_BUTTON(cancel));
-    }
+    vwm_load_popup_paint_focus(load_filedialog, load_focus);
 }
 
 static int
@@ -1192,68 +1154,15 @@ refresh_load_popup(void)
 static void
 load_popup_open(void)
 {
-    vwm_t   *vwm;
-    int     scr_width, scr_height;
-    int     pos_x, pos_y;
-    int     interior_w, interior_h;
-
     if(load_popup != NULL) return;
 
     load_last_click_item = -1;
     memset(&load_last_click_time, 0, sizeof(load_last_click_time));
     load_focus = LF_FILEDIALOG;
 
-    vwm = vwm_get_instance();
-    getmaxyx(vk_screen_get_window(vwm->screen), scr_height, scr_width);
-
-    load_popup = vk_popup_create(LOAD_WIDTH, LOAD_HEIGHT,
-        VK_BORDER_SINGLE, NULL);
-    vk_popup_set_title(load_popup, " Load Config ");
-    vk_popup_set_border_colors(load_popup, COLOR_WHITE, COLOR_BLUE);
-    vk_popup_set_border_attrs(load_popup, A_BOLD);
-
-    interior_w = LOAD_WIDTH - 2;
-    interior_h = LOAD_HEIGHT - 2;
-
-    load_filedialog = vk_filedialog_create(interior_w, interior_h,
-        VK_BORDER_SINGLE, false);
-    vk_filedialog_set_colors(load_filedialog, COLOR_WHITE, COLOR_BLUE);
-    vk_filedialog_set_highlight(load_filedialog, COLOR_BLACK, COLOR_RED);
-    vk_listbox_set_unfocused(
-        vk_filedialog_get_file_list(load_filedialog),
-        COLOR_BLACK, COLOR_WHITE);
-    vk_filedialog_set_button_colors(load_filedialog, COLOR_WHITE, COLOR_BLUE);
-    vk_filedialog_set_button_attrs(load_filedialog, A_BOLD);
-
-    {
-        char dirpath[PATH_MAX];
-        strncpy(dirpath, model->file_path, PATH_MAX - 1);
-        dirpath[PATH_MAX - 1] = '\0';
-
-        char *slash = strrchr(dirpath, '/');
-        if(slash != NULL && slash != dirpath)
-            *slash = '\0';
-        else if(slash == dirpath)
-            dirpath[1] = '\0';
-
-        vk_filedialog_set_path(load_filedialog, dirpath);
-    }
-
-    vk_filedialog_update(load_filedialog);
-
-    vk_popup_set_client(load_popup, VK_WIDGET(load_filedialog));
+    load_popup = vwm_load_popup_show(" Load Config ", &load_filedialog,
+        model->file_path);
     vk_object_set_kmio(VK_OBJECT(load_popup), load_popup_kmio);
-
-    pos_x = (scr_width - LOAD_WIDTH) / 2;
-    pos_y = (scr_height - LOAD_HEIGHT) / 2;
-    if(pos_x < 0) pos_x = 0;
-    if(pos_y < 0) pos_y = 0;
-
-    vk_widget_move(VK_WIDGET(load_popup), pos_x, pos_y);
-
-    vk_screen_attach_widget(vwm->screen,
-        vk_screen_get_active_surface(vwm->screen),
-        VK_WIDGET(load_popup));
 
     update_load_focus();
     refresh_load_popup();

--- a/manage_hotkeys.c
+++ b/manage_hotkeys.c
@@ -104,9 +104,6 @@ static int                  entry_to_lb[NUM_HOTKEYS];
 static struct timespec      list_last_click_time;
 static int                  list_last_click_item = -1;
 
-#define LOAD_WIDTH          50
-#define LOAD_HEIGHT         20
-
 static vk_popup_t           *load_popup = NULL;
 static vk_filedialog_t      *load_filedialog = NULL;
 static struct timespec       load_last_click_time;
@@ -720,41 +717,7 @@ hk_load_popup_ok(void)
 static void
 update_hk_load_focus(void)
 {
-    vk_widget_t *bar_w;
-    vk_widget_t *ok = NULL;
-    vk_widget_t *cancel = NULL;
-
-    if(load_filedialog == NULL) return;
-
-    bar_w = vk_box_get_widget(VK_BOX(load_filedialog), 2);
-    if(bar_w != NULL)
-    {
-        ok     = vk_box_get_widget(VK_BOX(bar_w), 0);
-        cancel = vk_box_get_widget(VK_BOX(bar_w), 1);
-    }
-
-    if(ok != NULL)
-    {
-        vk_button_release(VK_BUTTON(ok));
-        vk_widget_set_colors(ok,
-            (hk_load_focus == HL_OKAY) ? COLOR_YELLOW : COLOR_WHITE,
-            COLOR_BLUE);
-        vk_widget_set_attrs(ok, A_BOLD);
-        vk_button_update(VK_BUTTON(ok));
-    }
-
-    if(cancel != NULL)
-    {
-        vk_button_release(VK_BUTTON(cancel));
-        vk_widget_set_colors(cancel,
-            (hk_load_focus == HL_CANCEL) ? COLOR_YELLOW : COLOR_WHITE,
-            COLOR_BLUE);
-        vk_widget_set_attrs(cancel, A_BOLD);
-        vk_button_update(VK_BUTTON(cancel));
-    }
-
-    vk_listbox_set_focused(vk_filedialog_get_file_list(load_filedialog),
-        hk_load_focus == HL_FILEDIALOG);
+    vwm_load_popup_paint_focus(load_filedialog, hk_load_focus);
 }
 
 static int
@@ -830,76 +793,18 @@ refresh_load_popup(void)
 static void
 hk_load_popup_open(void)
 {
-    vwm_t   *vwm;
-    int     scr_width, scr_height;
-    int     pos_x, pos_y;
-    int     interior_w, interior_h;
-
     if(load_popup != NULL) return;
 
-    /* reset double-click tracker so the first click after open is a single */
     load_last_click_item = -1;
     memset(&load_last_click_time, 0, sizeof(load_last_click_time));
 
-    /* start with focus on the file browser */
     hk_load_focus = HL_FILEDIALOG;
 
-    vwm = vwm_get_instance();
-    getmaxyx(vk_screen_get_window(vwm->screen), scr_height, scr_width);
-
-    load_popup = vk_popup_create(LOAD_WIDTH, LOAD_HEIGHT,
-        VK_BORDER_SINGLE, NULL);
-    vk_popup_set_title(load_popup, " Load Config ");
-    vk_popup_set_border_colors(load_popup, COLOR_WHITE, COLOR_BLUE);
-    vk_popup_set_border_attrs(load_popup, A_BOLD);
-
-    interior_w = LOAD_WIDTH - 2;
-    interior_h = LOAD_HEIGHT - 2;
-
-    load_filedialog = vk_filedialog_create(interior_w, interior_h,
-        VK_BORDER_SINGLE, false);
-    vk_filedialog_set_colors(load_filedialog, COLOR_WHITE, COLOR_BLUE);
-    vk_filedialog_set_highlight(load_filedialog, COLOR_BLACK, COLOR_RED);
-    vk_listbox_set_unfocused(
-        vk_filedialog_get_file_list(load_filedialog),
-        COLOR_BLACK, COLOR_WHITE);
-    vk_filedialog_set_button_colors(load_filedialog,
-        COLOR_WHITE, COLOR_BLUE);
-    vk_filedialog_set_button_attrs(load_filedialog, A_BOLD);
-
-    {
-        char dirpath[PATH_MAX];
-        strncpy(dirpath, model->file_path, PATH_MAX - 1);
-        dirpath[PATH_MAX - 1] = '\0';
-
-        char *slash = strrchr(dirpath, '/');
-        if(slash != NULL && slash != dirpath)
-            *slash = '\0';
-        else if(slash == dirpath)
-            dirpath[1] = '\0';
-
-        vk_filedialog_set_path(load_filedialog, dirpath);
-    }
-
-    vk_filedialog_update(load_filedialog);
-
-    /* paint initial button colors so they read as inactive */
-    update_hk_load_focus();
-
-    vk_popup_set_client(load_popup, VK_WIDGET(load_filedialog));
+    load_popup = vwm_load_popup_show(" Load Config ", &load_filedialog,
+        model->file_path);
     vk_object_set_kmio(VK_OBJECT(load_popup), hk_load_popup_kmio);
 
-    pos_x = (scr_width - LOAD_WIDTH) / 2;
-    pos_y = (scr_height - LOAD_HEIGHT) / 2;
-    if(pos_x < 0) pos_x = 0;
-    if(pos_y < 0) pos_y = 0;
-
-    vk_widget_move(VK_WIDGET(load_popup), pos_x, pos_y);
-
-    vk_screen_attach_widget(vwm->screen,
-        vk_screen_get_active_surface(vwm->screen),
-        VK_WIDGET(load_popup));
-
+    update_hk_load_focus();
     refresh_load_popup();
 }
 

--- a/manage_settings.c
+++ b/manage_settings.c
@@ -189,9 +189,6 @@ static int                 modify_focus = 0;
 static struct timespec     list_last_click_time;
 static int                 list_last_click_item = -1;
 
-#define LOAD_WIDTH          50
-#define LOAD_HEIGHT         20
-
 static vk_popup_t          *load_popup = NULL;
 static vk_filedialog_t     *load_filedialog = NULL;
 static vk_popup_t          *warning_popup = NULL;
@@ -1767,78 +1764,16 @@ refresh_load_popup(void)
 static void
 load_popup_open(void)
 {
-    vwm_t       *vwm;
-    int         scr_w, scr_h;
-    int         interior_w, interior_h;
-    int         pos_x, pos_y;
-
     if(load_popup != NULL) return;
 
     load_last_click_item = -1;
     memset(&load_last_click_time, 0, sizeof(load_last_click_time));
 
-    vwm = vwm_get_instance();
-    getmaxyx(vk_screen_get_window(vwm->screen), scr_h, scr_w);
-
-    load_popup = vk_popup_create(LOAD_WIDTH, LOAD_HEIGHT,
-        VK_BORDER_SINGLE, NULL);
-    vk_popup_set_title(load_popup, " Load Settings ");
-    vk_popup_set_border_colors(load_popup, COLOR_WHITE, COLOR_BLUE);
-    vk_popup_set_border_attrs(load_popup, A_BOLD);
-
-    interior_w = LOAD_WIDTH - 2;
-    interior_h = LOAD_HEIGHT - 2;
-
-    load_filedialog = vk_filedialog_create(interior_w, interior_h,
-        VK_BORDER_SINGLE, false);
-    vk_filedialog_set_colors(load_filedialog, COLOR_WHITE, COLOR_BLUE);
-    vk_filedialog_set_highlight(load_filedialog, COLOR_BLACK, COLOR_RED);
-    vk_listbox_set_unfocused(
-        vk_filedialog_get_file_list(load_filedialog),
-        COLOR_BLACK, COLOR_WHITE);
-    vk_filedialog_set_button_colors(load_filedialog,
-        COLOR_WHITE, COLOR_BLUE);
-    vk_filedialog_set_button_attrs(load_filedialog, A_BOLD);
-
-    {
-        char dirpath[PATH_MAX];
-        strncpy(dirpath, model->file_path, PATH_MAX - 1);
-        dirpath[PATH_MAX - 1] = '\0';
-
-        char *slash = strrchr(dirpath, '/');
-        if(slash != NULL && slash != dirpath)
-            *slash = '\0';
-        else if(slash == dirpath)
-            dirpath[1] = '\0';
-
-        vk_filedialog_set_path(load_filedialog, dirpath);
-    }
-
-    vk_filedialog_update(load_filedialog);
-
-    vk_popup_set_client(load_popup, VK_WIDGET(load_filedialog));
-
-    {
-        uint32_t st = vk_widget_get_state(VK_WIDGET(load_filedialog));
-        vk_widget_set_state(VK_WIDGET(load_filedialog),
-            st & ~VK_STATE_EXPAND);
-    }
-
+    load_popup = vwm_load_popup_show(" Load Settings ", &load_filedialog,
+        model->file_path);
     vk_object_set_kmio(VK_OBJECT(load_popup), load_popup_kmio);
 
-    pos_x = (scr_w - LOAD_WIDTH) / 2;
-    pos_y = (scr_h - LOAD_HEIGHT) / 2;
-    if(pos_x < 0) pos_x = 0;
-    if(pos_y < 0) pos_y = 0;
-
-    vk_widget_move(VK_WIDGET(load_popup), pos_x, pos_y);
-
-    vk_screen_attach_widget(vwm->screen,
-        vk_screen_get_active_surface(vwm->screen),
-        VK_WIDGET(load_popup));
-
-    vk_popup_update(load_popup);
-    vk_screen_refresh(vwm->screen);
+    refresh_load_popup();
 }
 
 /* ── actions ──────────────────────────────────────────────── */

--- a/manage_ui_common.c
+++ b/manage_ui_common.c
@@ -1,4 +1,5 @@
 #include <ncursesw/curses.h>
+#include <string.h>
 
 #include <vdk.h>
 
@@ -302,6 +303,120 @@ vwm_confirm_popup_show(void)
     vk_screen_refresh(vwm->screen);
 
     return popup;
+}
+
+vk_popup_t *
+vwm_load_popup_show(const char *title, vk_filedialog_t **filedialog,
+    const char *cur_path)
+{
+    vwm_t           *vwm;
+    vk_popup_t      *popup;
+    vk_filedialog_t *fd;
+    int             scr_w, scr_h;
+    int             interior_w, interior_h;
+    int             pos_x, pos_y;
+    const int       popup_w = 50;   /* matches each dialog's former LOAD_WIDTH  */
+    const int       popup_h = 20;   /* matches each dialog's former LOAD_HEIGHT */
+
+    vwm = vwm_get_instance();
+    getmaxyx(vk_screen_get_window(vwm->screen), scr_h, scr_w);
+
+    popup = vk_popup_create(popup_w, popup_h, VK_BORDER_SINGLE, NULL);
+    vk_popup_set_title(popup, title);
+    vk_popup_set_border_colors(popup, COLOR_WHITE, COLOR_BLUE);
+    vk_popup_set_border_attrs(popup, A_BOLD);
+
+    interior_w = popup_w - 2;
+    interior_h = popup_h - 2;
+
+    fd = vk_filedialog_create(interior_w, interior_h,
+        VK_BORDER_SINGLE, false);
+    vk_filedialog_set_colors(fd, COLOR_WHITE, COLOR_BLUE);
+    vk_filedialog_set_highlight(fd, COLOR_BLACK, COLOR_RED);
+    vk_listbox_set_unfocused(vk_filedialog_get_file_list(fd),
+        COLOR_BLACK, COLOR_WHITE);
+    vk_filedialog_set_button_colors(fd, COLOR_WHITE, COLOR_BLUE);
+    vk_filedialog_set_button_attrs(fd, A_BOLD);
+
+    {
+        char dirpath[PATH_MAX];
+        char *slash;
+
+        strncpy(dirpath, cur_path, PATH_MAX - 1);
+        dirpath[PATH_MAX - 1] = '\0';
+
+        slash = strrchr(dirpath, '/');
+        if(slash != NULL && slash != dirpath)
+            *slash = '\0';
+        else if(slash == dirpath)
+            dirpath[1] = '\0';
+
+        vk_filedialog_set_path(fd, dirpath);
+    }
+
+    vk_filedialog_update(fd);
+
+    vk_popup_set_client(popup, VK_WIDGET(fd));
+
+    {
+        uint32_t st = vk_widget_get_state(VK_WIDGET(fd));
+        vk_widget_set_state(VK_WIDGET(fd), st & ~VK_STATE_EXPAND);
+    }
+
+    pos_x = (scr_w - popup_w) / 2;
+    pos_y = (scr_h - popup_h) / 2;
+    if(pos_x < 0) pos_x = 0;
+    if(pos_y < 0) pos_y = 0;
+
+    vk_widget_move(VK_WIDGET(popup), pos_x, pos_y);
+
+    vk_screen_attach_widget(vwm->screen,
+        vk_screen_get_active_surface(vwm->screen),
+        VK_WIDGET(popup));
+
+    *filedialog = fd;
+    return popup;
+}
+
+void
+vwm_load_popup_paint_focus(vk_filedialog_t *filedialog, int focus)
+{
+    vk_widget_t *bar_w;
+    vk_widget_t *ok = NULL;
+    vk_widget_t *cancel = NULL;
+
+    if(filedialog == NULL) return;
+
+    /* the file browser is highlighted only while it holds focus */
+    vk_listbox_set_focused(vk_filedialog_get_file_list(filedialog),
+        focus == VWM_LOAD_FOCUS_FILEDIALOG);
+
+    bar_w = vk_box_get_widget(VK_BOX(filedialog), 2);
+    if(bar_w != NULL)
+    {
+        ok     = vk_box_get_widget(VK_BOX(bar_w), 0);
+        cancel = vk_box_get_widget(VK_BOX(bar_w), 1);
+    }
+
+    if(ok != NULL)
+    {
+        vk_button_release(VK_BUTTON(ok));
+        vk_widget_set_colors(ok,
+            (focus == VWM_LOAD_FOCUS_OK) ? COLOR_YELLOW : COLOR_WHITE,
+            COLOR_BLUE);
+        vk_widget_set_attrs(ok, A_BOLD);
+        vk_button_update(VK_BUTTON(ok));
+    }
+
+    if(cancel != NULL)
+    {
+        vk_button_release(VK_BUTTON(cancel));
+        vk_widget_set_colors(cancel,
+            (focus == VWM_LOAD_FOCUS_CANCEL) ? COLOR_YELLOW : COLOR_WHITE,
+            COLOR_BLUE);
+        vk_widget_set_attrs(cancel, A_BOLD);
+        vk_button_update(VK_BUTTON(cancel));
+    }
 }
 
 vk_popup_t *

--- a/manage_ui_common.h
+++ b/manage_ui_common.h
@@ -36,4 +36,26 @@ vk_popup_t *vwm_saved_popup_show(const char *msg);
    active-button index.  Shared by Settings / Hotkeys / Apps. */
 vk_popup_t *vwm_confirm_popup_show(void);
 
+/* Focus targets for the Load popup's Tab cycle (file browser -> OK ->
+   Cancel); mirrors the per-dialog focus orderings in Hotkeys / Apps. */
+enum {
+    VWM_LOAD_FOCUS_FILEDIALOG = 0,
+    VWM_LOAD_FOCUS_OK,
+    VWM_LOAD_FOCUS_CANCEL,
+    VWM_LOAD_FOCUS_COUNT
+};
+
+/* Build, center, and attach the shared white-on-blue file-load popup
+   titled `title`, holding a vk_filedialog rooted at the directory of
+   `cur_path`; the filedialog is returned through *filedialog.  The
+   caller sets the popup's kmio, stores the pointer, and refreshes.
+   Shared by Settings / Hotkeys / Apps. */
+vk_popup_t *vwm_load_popup_show(const char *title,
+    vk_filedialog_t **filedialog, const char *cur_path);
+
+/* Repaint the load filedialog's OK / Cancel buttons and file-list
+   highlight for the given focus (a VWM_LOAD_FOCUS_* value).  Used by the
+   Hotkeys / Apps load dialogs, which Tab between browser and buttons. */
+void vwm_load_popup_paint_focus(vk_filedialog_t *filedialog, int focus);
+
 #endif


### PR DESCRIPTION
Settings, Hotkeys and Apps each built the identical 50x20 white-on-blue file-load popup (a vk_filedialog rooted at the config directory) in a ~75-line load_popup_open that differed only by the window title.  Move the construction to manage_ui_common as vwm_load_popup_show(title, &fd, cur_path); each dialog's open is now a short wrapper that calls it, sets its own kmio, paints focus, and refreshes.

Also fold the OK/Cancel focus painting shared by the Hotkeys and Apps load dialogs (Settings has no focus layer) into
vwm_load_popup_paint_focus(fd, focus), keyed by a shared VWM_LOAD_FOCUS_* enum; update_hk_load_focus / update_load_focus are now one-line delegates.

The per-dialog LOAD_WIDTH / LOAD_HEIGHT defines (only ever used by the open) are removed; the shared builder uses the same 50x20.  One drift folded: only Settings cleared VK_STATE_EXPAND on the filedialog -- the shared builder always does, matching every other popup's client.  The kmio / ok / close / refresh stay per-dialog (interactive logic and per-model load handling woven around the per-dialog pointers).