### PR TITLE
fix(vwmterm): clear cloned bin_path/exec_args to stop a launch use-af…

### DIFF
--- a/modules/vwmterm3/module.c
+++ b/modules/vwmterm3/module.c
@@ -23,6 +23,17 @@ vwmterm_module_clone(vwm_module_t *mod)
     // memcpy the entire module
     memcpy(vwmterm_mod, mod, sizeof(vwmterm_mod_t));
 
+    /* The memcpy copied the source's heap-owned pointers.  Clear them so
+       the clone owns nothing yet -- configure() allocates fresh copies.
+       Without this, cloning an already-configured module (which
+       vwm_module_find_by_name returns, since clones keep the template
+       name and land at the list head) would share bin_path/exec_args with
+       the source, and configure()'s free-then-strdup would leave the
+       source dangling: a use-after-free that launches the wrong program
+       or crashes. */
+    vwmterm_mod->bin_path = NULL;
+    vwmterm_mod->exec_args = NULL;
+
     return VWM_MODULE(vwmterm_mod);
 }
 


### PR DESCRIPTION
…ter-free

Regression from the %fd work (the configure free-old change): launching an app could start the wrong program or crash, worsening with each menu entry.

vwmterm_module_clone() memcpy's the whole module, copying the source's bin_path/exec_args pointers.  Program clones keep the template's name and vwm_module_add() puts them at the list head, so vwm_module_find_by_name() returns the most-recently-added, already-configured clone -- meaning each new program is cloned from the previous program's module and shares its bin_path/exec_args.  vwmterm_module_configure() now frees the old strings before strdup'ing the new ones, so configuring the new clone freed the previous program's bin_path; the freed block was then reused by the next strdup, so e.g. launching htop execed bastest, and other entries hit freed/garbage pointers and crashed.  (The pre-%fd code tolerated the sharing only because it overwrote without freeing.)

Null bin_path/exec_args in the clone right after the memcpy so the clone owns nothing until configure() allocates fresh copies.  free-old then only ever frees this clone's own strings (or NULL on first config), never the source's.