### PR TITLE
fix(vwmterm): initialise bytes_read so the exit-path check is defined…

### DIFF
--- a/modules/vwmterm3/pt_thread.c
+++ b/modules/vwmterm3/pt_thread.c
@@ -48,7 +48,7 @@ pt_t vwmterm_thd(void * const env)
     vwm_t               *vwm;
     vk_window_t         *window;
     vterm_t             *vterm;
-    ssize_t             bytes_read;
+    ssize_t             bytes_read = 0;
     int                 i;
     int                 history_sz;
     int                 width, height;


### PR DESCRIPTION
… (M2)

vwmterm_thd reads bytes_read in the post-loop window-close check (if(*shutdown || bytes_read == -1)), but bytes_read is only assigned inside the drain loop -- after the VWMTERM_STATE_EXITING break at the top of the loop body.  When the loop exits via that break (the state is set when the window/child closes) with the global shutdown flag false, the bytes_read == -1 term is evaluated on an uninitialised value: valgrind's "conditional jump depends on uninitialised value(s)" at vwmterm_thd (M2), and a non-deterministic window-close on that path.  Being a protothread, a mid-loop resume past the in-loop assignment widens the affected paths.

Initialise bytes_read at its declaration, which runs before pt_resume on every entry, so the post-loop check is always defined.  On the EXITING path it reduces to *shutdown -- the intended "close only on a real shutdown or EPIPE" behaviour.