### PR TITLE
popups: don't close the tool dialogs on an outside click

### DIFF
--- a/launch_picker.c
+++ b/launch_picker.c
@@ -229,14 +229,10 @@ launch_picker_mouse(MEVENT *me)
     ix = me->x - wx - 1;
     iy = me->y - wy - 1;
 
-    /* off the dialog -> abort the launch on a real press fully off the
-       window (not merely on its border), matching the other popups */
+    /* off the dialog -- ignore.  A press off the window no longer aborts
+       the launch; use Cancel or Esc to dismiss the picker. */
     if(ix < 0 || ix >= ww - 2 || iy < 0 || iy >= wh - 2)
     {
-        if((bs & BUTTON1_PRESSED) &&
-           (me->x < wx || me->x >= wx + ww ||
-            me->y < wy || me->y >= wy + wh))
-            launch_picker_close();
         return;
     }
 

--- a/manage_windows.c
+++ b/manage_windows.c
@@ -1117,13 +1117,8 @@ vwm_manage_windows_mouse(MEVENT *mouse_event)
 
     if(rel_x < 0 || rel_x >= ww || rel_y < 0 || rel_y >= wh)
     {
-        /* clicked outside the dialog (e.g. on the desktop) -- dismiss it,
-           matching the lost-focus close the apps/hotkeys/settings popups
-           get from poll_input.  Only a real button press closes it, so
-           hover-moves don't; the move/warning sub-popups are handled
-           above and never reach here. */
-        if(mouse_event->bstate & BUTTON1_PRESSED)
-            vwm_manage_windows_close();
+        /* clicked outside the dialog -- ignore.  It no longer dismisses
+           the dialog; close it with the Close/Cancel button or Esc. */
         return 0;
     }
 

--- a/modules/vwmprint/init.c
+++ b/modules/vwmprint/init.c
@@ -743,12 +743,8 @@ handle_mouse(MEVENT *me)
 
     if(ix < 0 || ix >= ww - 2 || iy < 0 || iy >= wh - 2)
     {
-        /* clicked outside the dialog -- dismiss on a real button press,
-           but only when fully off the window (not just on its border),
-           matching Manage Desktop and the apps/hotkeys/settings popups */
-        if((bs & BUTTON1_PRESSED) &&
-           (me->x < wx || me->x >= wx + ww || me->y < wy || me->y >= wy + wh))
-            close_session();
+        /* off the dialog -- ignore.  A press off the window no longer
+           dismisses the print tool; use Cancel or Esc instead. */
         return;
     }
 

--- a/modules/vwmscrshot/init.c
+++ b/modules/vwmscrshot/init.c
@@ -737,12 +737,8 @@ handle_mouse(MEVENT *me)
 
     if(ix < 0 || ix >= ww - 2 || iy < 0 || iy >= wh - 2)
     {
-        /* clicked outside the dialog -- dismiss on a real button press,
-           but only when fully off the window (not just on its border),
-           matching Manage Desktop and the apps/hotkeys/settings popups */
-        if((bs & BUTTON1_PRESSED) &&
-           (me->x < wx || me->x >= wx + ww || me->y < wy || me->y >= wy + wh))
-            close_session();
+        /* off the dialog -- ignore.  A press off the window no longer
+           dismisses the screenshot tool; use Cancel or Esc instead. */
         return;
     }
 

--- a/poll_input_thd.c
+++ b/poll_input_thd.c
@@ -364,26 +364,11 @@ vwm_poll_input(void * const env)
             zone = classify_mouse(vwm, mouse_event->x,
                 mouse_event->y, &hit);
 
-            if(vwm->manage_hotkeys_popup != NULL &&
-               zone != ZONE_MANAGE_HOTKEYS &&
-               (bs & BUTTON1_PRESSED))
-            {
-                vwm_manage_hotkeys_close();
-            }
-
-            if(vwm->manage_settings_popup != NULL &&
-               zone != ZONE_MANAGE_SETTINGS &&
-               (bs & BUTTON1_PRESSED))
-            {
-                vwm_manage_settings_close();
-            }
-
-            if(vwm->manage_apps_popup != NULL &&
-               zone != ZONE_MANAGE_APPS &&
-               (bs & BUTTON1_PRESSED))
-            {
-                vwm_manage_apps_close();
-            }
+            /* Manage Apps / Hotkeys / Settings intentionally do NOT close
+               on an outside click -- dismiss them with their Close/Cancel
+               button or Esc.  (The menubar dropdown and calendar popup
+               below still close on an outside press, which is the
+               conventional behavior for a menu / transient popup.) */
 
             if(vwm->menu != NULL && zone != ZONE_MENU &&
                zone != ZONE_PANEL && (bs & BUTTON1_PRESSED))


### PR DESCRIPTION
Clicking outside a popup tool dismissed it, which is no longer wanted. Remove the outside-click close from the tool popups:

  * Manage Apps / Hotkeys / Settings -- drop the lost-focus close in poll_input_thd.c (the press-outside-its-zone -> _close block).
  * Manage Windows -- its own kmio dismissed on a press outside the dialog bounds; that branch is now a no-op return.
  * Launch Picker -- a press fully off the window aborted the launch; now ignored.
  * Print File (vwmprint) and Screenshot (vwmscrshot) -- their handle_mouse dismissed the surface-attached tool on a press off the window; now ignored.

These dialogs are dismissed with their Close/Cancel button or Esc. The menubar dropdown and the calendar popup are intentionally left alone -- closing a menu / transient popup on an outside press is the expected behavior.  No new behavior is introduced: the outside click already fell through to the zone switch, so backgrounded windows react exactly as before, only without the dialog closing.