### PR TITLE
filepickers: grey active selection instead of red

### DIFF
--- a/manage_ui_common.c
+++ b/manage_ui_common.c
@@ -332,7 +332,8 @@ vwm_load_popup_show(const char *title, vk_filedialog_t **filedialog,
     fd = vk_filedialog_create(interior_w, interior_h,
         VK_BORDER_SINGLE, false);
     vk_filedialog_set_colors(fd, COLOR_WHITE, COLOR_BLUE);
-    vk_filedialog_set_highlight(fd, COLOR_BLACK, COLOR_RED);
+    /* grey active selection (matches the unfocused row), not red */
+    vk_filedialog_set_highlight(fd, COLOR_BLACK, COLOR_WHITE);
     vk_listbox_set_unfocused(vk_filedialog_get_file_list(fd),
         COLOR_BLACK, COLOR_WHITE);
     vk_filedialog_set_button_colors(fd, COLOR_WHITE, COLOR_BLUE);

--- a/modules/vwmprint/init.c
+++ b/modules/vwmprint/init.c
@@ -211,7 +211,8 @@ build_pick(print_session_t *s)
 
     fd = vk_filedialog_create(W - 2, H - 2, VK_BORDER_SINGLE, false);
     vk_filedialog_set_colors(fd, COLOR_WHITE, COLOR_BLUE);
-    vk_filedialog_set_highlight(fd, COLOR_BLACK, COLOR_RED);
+    /* grey active selection (matches the unfocused row), not red */
+    vk_filedialog_set_highlight(fd, COLOR_BLACK, COLOR_WHITE);
     vk_listbox_set_unfocused(vk_filedialog_get_file_list(fd),
         COLOR_BLACK, COLOR_WHITE);
     vk_filedialog_set_button_colors(fd, COLOR_WHITE, COLOR_BLUE);

--- a/modules/vwmscrshot/init.c
+++ b/modules/vwmscrshot/init.c
@@ -422,7 +422,8 @@ build_save(scrshot_session_t *s)
 
     fd = vk_filedialog_create(W - 2, fd_h, VK_BORDER_SINGLE, false);
     vk_filedialog_set_colors(fd, COLOR_WHITE, COLOR_BLUE);
-    vk_filedialog_set_highlight(fd, COLOR_BLACK, COLOR_RED);
+    /* grey active selection (matches the unfocused row), not red */
+    vk_filedialog_set_highlight(fd, COLOR_BLACK, COLOR_WHITE);
     vk_listbox_set_unfocused(vk_filedialog_get_file_list(fd),
         COLOR_BLACK, COLOR_WHITE);
     vk_filedialog_set_button_colors(fd, COLOR_WHITE, COLOR_BLUE);


### PR DESCRIPTION
The file pickers highlighted the focused current item in red (COLOR_BLACK on COLOR_RED).  Use the same grey the unfocused row uses (COLOR_BLACK on COLOR_WHITE) -- softer and consistent.  Affects:

  * Print File (vwmprint)
  * the shared load popup (manage_ui_common) -- the %fd file picker launched by apps, plus the Load Config / Load Settings dialogs
  * Screenshot save picker (vwmscrshot) -- already appeared grey because its list is usually unfocused; this keeps it grey when focused too

The non-filepicker listboxes (windows / hotkeys / settings / app / printer lists, calendar) keep their red highlight -- unchanged.