### PR TITLE
settings: optional bottom-left hostname label

### DIFF
--- a/bkgd.c
+++ b/bkgd.c
@@ -21,6 +21,7 @@
 #include <string.h>
 #include <stdlib.h>
 #include <stdbool.h>
+#include <unistd.h>
 #include <wchar.h>
 #include <langinfo.h>
 
@@ -340,6 +341,59 @@ _bkgd_paint_into(WINDOW *target, int surface_id, int width, int height)
     }
 }
 
+/*
+    Draw the host name in the desktop's bottom-left corner: one column in
+    from the left edge, with one blank row between it and the bottom
+    status line (status sits at height-1, so the name goes at height-3).
+    Must be called AFTER the wallpaper is painted onto the canvas, or the
+    wallpaper blit overwrites it.  Gated by the Settings "Show Hostname"
+    option (off by default); colored by the "Hostname Colors" option,
+    applied via wattr_set so bright (8-15) colors survive.
+*/
+static void
+_bkgd_draw_hostname(WINDOW *canvas, int surface_id, int width, int height)
+{
+    static char     host[256] = "";
+    vwm_t           *vwm;
+    char            *dot;
+    short           fg, bg, pair;
+    int             row, col, len;
+
+    (void)surface_id;
+
+    vwm = vwm_get_instance();
+    if(vwm == NULL || !vwm->show_hostname) return;
+
+    if(host[0] == '\0')
+    {
+        if(gethostname(host, sizeof(host)) != 0) return;
+        host[sizeof(host) - 1] = '\0';
+        /* short name only -- drop any domain suffix */
+        dot = strchr(host, '.');
+        if(dot != NULL) *dot = '\0';
+        if(host[0] == '\0') return;
+    }
+
+    if(height < 3 || width < 2) return;
+
+    row = height - 3;       /* status at height-1, blank row at height-2 */
+    col = 1;                /* one column in from the left edge */
+
+    len = (int)strlen(host);
+    if(col + len > width) len = width - col;
+    if(len <= 0) return;
+
+    fg = vwm->hostname_fg;
+    bg = vwm->hostname_bg;
+    if(fg < 0 || fg > 15) fg = COLOR_WHITE;
+    if(bg < 0 || bg > 15) bg = COLOR_BLUE;
+    pair = vdk_color_pair(fg, bg);
+
+    wattr_set(canvas, A_BOLD, pair, NULL);
+    mvwaddnstr(canvas, row, col, host, len);
+    wattr_set(canvas, A_NORMAL, 0, NULL);
+}
+
 void
 vwm_bkgd_simple_normal(vk_screen_t *screen, int surface_id, WINDOW *canvas)
 {
@@ -353,6 +407,7 @@ vwm_bkgd_simple_normal(vk_screen_t *screen, int surface_id, WINDOW *canvas)
         /* out-of-range slot -- paint directly, no caching */
         getmaxyx(canvas, height, width);
         _bkgd_paint_into(canvas, surface_id, width, height);
+        _bkgd_draw_hostname(canvas, surface_id, width, height);
         return;
     }
 
@@ -375,6 +430,7 @@ vwm_bkgd_simple_normal(vk_screen_t *screen, int surface_id, WINDOW *canvas)
         {
             /* newwin failed -- paint directly so we don't lose a frame */
             _bkgd_paint_into(canvas, surface_id, width, height);
+            _bkgd_draw_hostname(canvas, surface_id, width, height);
             return;
         }
         _bkgd_paint_into(g_wallpaper_cache[surface_id],
@@ -385,6 +441,10 @@ vwm_bkgd_simple_normal(vk_screen_t *screen, int surface_id, WINDOW *canvas)
        destination rectangle, blanks included -- identical effect to
        overwrite() but explicit about the rectangle and the mode. */
     overwrite(g_wallpaper_cache[surface_id], canvas);
+
+    /* host name in the bottom-left -- drawn after the wallpaper blit so it
+       is not overpainted (see _bkgd_draw_hostname). */
+    _bkgd_draw_hostname(canvas, surface_id, width, height);
 }
 
 /*

--- a/manage_settings.c
+++ b/manage_settings.c
@@ -31,13 +31,14 @@
 #define INTERIOR_WIDTH      (DIALOG_WIDTH - 2)
 #define INTERIOR_HEIGHT     (DIALOG_HEIGHT - 2)
 
-/* base settings = 5.  Desktop N Color and Desktop N Wallpaper rows
-   are dynamic, packed densely after the base rows in this order:
-        rows [5 .. 5+sc-1]              : Desktop N Color
-        rows [5+sc .. 5+2*sc-1]         : Desktop N Wallpaper
-   where sc = vwm->surface_count.  Storage covers the max so the array
-   size never grows; positions beyond active_setting_count are unused. */
-#define NUM_BASE_SETTINGS               6
+/* NUM_BASE_SETTINGS fixed rows come first.  Desktop N Color and Desktop
+   N Wallpaper rows are dynamic, packed densely after the base rows:
+        rows [B .. B+sc-1]             : Desktop N Color
+        rows [B+sc .. B+2*sc-1]        : Desktop N Wallpaper
+   where B = SETTING_DESKTOP_COLOR_BASE (= NUM_BASE_SETTINGS) and
+   sc = vwm->surface_count.  Storage covers the max so the array size
+   never grows; positions beyond active_setting_count are unused. */
+#define NUM_BASE_SETTINGS               8
 #define NUM_SETTINGS                    (NUM_BASE_SETTINGS + 2 * VWM_MAX_DESKTOPS)
 #define MAX_APP_OPTIONS                 64
 
@@ -47,6 +48,8 @@
 #define SETTING_SCREENSAVER_CMD         3
 #define SETTING_SCREENSAVER_IDLE        4
 #define SETTING_CLIPBOARD               5
+#define SETTING_SHOW_HOSTNAME           6
+#define SETTING_HOSTNAME_COLOR          7
 #define SETTING_DESKTOP_COLOR_BASE      NUM_BASE_SETTINGS
 
 #define SETTING_TYPE_DROPDOWN   0
@@ -82,11 +85,16 @@ base_setting_defs[NUM_BASE_SETTINGS] =
     { "Screensaver Cmd",     SETTING_TYPE_INPUT },
     { "Screensaver Idle",    SETTING_TYPE_INPUT },
     { "Copy to Clipboard",   SETTING_TYPE_DROPDOWN },
+    { "Show Hostname",       SETTING_TYPE_DROPDOWN },
+    { "Hostname Colors",     SETTING_TYPE_COLOR },
 };
 
 /* labels for the dynamic Desktop N Color / Desktop N Wallpaper rows */
 static char desktop_color_labels[VWM_MAX_DESKTOPS][32];
 static char desktop_wallpaper_labels[VWM_MAX_DESKTOPS][32];
+
+/* Show Hostname toggle values (index 0 = off, 1 = on) */
+static const char *hostname_toggle_names[2] = { "Off", "On" };
 
 static const char*
 get_setting_label(int idx)
@@ -226,6 +234,7 @@ static int                 load_last_click_item = -1;
 static void rebuild_listbox(void);
 static void refresh_dialog(void);
 static void refresh_load_popup(void);
+static void parse_fg_bg(const char *val, int *fg_out, int *bg_out);
 static int  manage_settings_kmio(vk_object_t *object, int32_t keystroke);
 
 /* ── app options population ───────────────────────────────── */
@@ -282,6 +291,19 @@ model_load_from_vwm(vwm_t *vwm)
         strncpy(model->values[SETTING_CLIPBOARD],
             vwm_clipboard_mode_names[cidx], NAME_MAX - 1);
         model->values[SETTING_CLIPBOARD][NAME_MAX - 1] = '\0';
+    }
+
+    strncpy(model->values[SETTING_SHOW_HOSTNAME],
+        hostname_toggle_names[vwm->show_hostname ? 1 : 0], NAME_MAX - 1);
+    model->values[SETTING_SHOW_HOSTNAME][NAME_MAX - 1] = '\0';
+
+    {
+        int hf = vwm->hostname_fg;
+        int hb = vwm->hostname_bg;
+        if(hf < 0 || hf > 15) hf = COLOR_WHITE;
+        if(hb < 0 || hb > 15) hb = COLOR_BLUE;
+        snprintf(model->values[SETTING_HOSTNAME_COLOR], NAME_MAX,
+            "%s/%s", vwm_color_names[hf], vwm_color_names[hb]);
     }
 
     /* dynamic rows: Desktop N Color, then Desktop N Wallpaper.  Storage
@@ -364,6 +386,19 @@ model_load_from_config(const char *path)
     if(str != NULL)
         strncpy(model->values[SETTING_CLIPBOARD], str, NAME_MAX - 1);
 
+    item = cJSON_GetObjectItemCaseSensitive(settings, "show_hostname");
+    if(cJSON_IsNumber(item))
+        strncpy(model->values[SETTING_SHOW_HOSTNAME],
+            item->valueint ? "On" : "Off", NAME_MAX - 1);
+
+    {
+        const char *hf = vwm_json_str(settings, "hostname_fg", NULL);
+        const char *hb = vwm_json_str(settings, "hostname_bg", NULL);
+        if(hf != NULL && hb != NULL)
+            snprintf(model->values[SETTING_HOSTNAME_COLOR], NAME_MAX,
+                "%s/%s", hf, hb);
+    }
+
     cJSON_Delete(root);
 }
 
@@ -398,6 +433,16 @@ commit_to_vwm(void)
                 break;
             }
         }
+    }
+
+    vwm->show_hostname =
+        (strcmp(model->values[SETTING_SHOW_HOSTNAME], "On") == 0) ? 1 : 0;
+
+    {
+        int fg = COLOR_WHITE, bg = COLOR_BLUE;
+        parse_fg_bg(model->values[SETTING_HOSTNAME_COLOR], &fg, &bg);
+        vwm->hostname_fg = (short)fg;
+        vwm->hostname_bg = (short)bg;
     }
 
     /* commit each visible Desktop N Color and Desktop N Wallpaper row
@@ -568,6 +613,15 @@ cycle_value(int setting_idx, int direction)
             strncpy(model->values[setting_idx],
                 model->app_titles[curr - 1], NAME_MAX - 1);
     }
+    else if(setting_idx == SETTING_SHOW_HOSTNAME)
+    {
+        /* two-state toggle -- direction is irrelevant */
+        (void)direction;
+        strncpy(model->values[setting_idx],
+            (strcmp(model->values[setting_idx], "On") == 0) ? "Off" : "On",
+            NAME_MAX - 1);
+        model->values[setting_idx][NAME_MAX - 1] = '\0';
+    }
 
     model->dirty = true;
     rebuild_listbox();
@@ -718,6 +772,12 @@ modify_popup_apply(void)
                     if(curr >= 0 && curr < VWM_CLIPBOARD_COUNT)
                         strncpy(model->values[modify_setting_idx],
                             vwm_clipboard_mode_names[curr], NAME_MAX - 1);
+                }
+                else if(modify_setting_idx == SETTING_SHOW_HOSTNAME)
+                {
+                    if(curr >= 0 && curr < 2)
+                        strncpy(model->values[modify_setting_idx],
+                            hostname_toggle_names[curr], NAME_MAX - 1);
                 }
                 else if(curr < VWM_WALLPAPER_COUNT)
                 {
@@ -1120,6 +1180,17 @@ modify_popup_open(int setting_idx)
                     (char *)vwm_clipboard_mode_names[i], NULL, NULL);
                 if(strcmp(model->values[setting_idx],
                     vwm_clipboard_mode_names[i]) == 0)
+                    sel_idx = i;
+            }
+        }
+        else if(setting_idx == SETTING_SHOW_HOSTNAME)
+        {
+            for(i = 0; i < 2; i++)
+            {
+                vk_listbox_add_item(modify_listbox,
+                    (char *)hostname_toggle_names[i], NULL, NULL);
+                if(strcmp(model->values[setting_idx],
+                    hostname_toggle_names[i]) == 0)
                     sel_idx = i;
             }
         }

--- a/private.h
+++ b/private.h
@@ -75,6 +75,12 @@ struct _vwm_s
     /* VWM_CLIPBOARD_* -- how SELECT-mode copy reaches the host clipboard */
     short                   clipboard_mode;
 
+    /* bottom-left hostname label (Settings: Show Hostname + Hostname
+       Colors).  show_hostname 0 = off (default), 1 = on. */
+    short                   show_hostname;
+    short                   hostname_fg;
+    short                   hostname_bg;
+
     uint32_t                state;
 
     int                     cursor_x;

--- a/settings.c
+++ b/settings.c
@@ -186,6 +186,30 @@ vwm_settings_load_general(vwm_t *vwm)
         }
     }
 
+    /* bottom-left hostname label: on/off flag plus its fg/bg colors
+       (stored as color names like the desktop colors). */
+    val = vwm_json_int(settings, "show_hostname", -1);
+    if(val == 0 || val == 1)
+        vwm->show_hostname = (short)val;
+
+    str = vwm_json_str(settings, "hostname_fg", NULL);
+    if(str != NULL)
+    {
+        int j;
+        for(j = 0; j < 16; j++)
+            if(strcmp(str, vwm_color_names[j]) == 0)
+            { vwm->hostname_fg = (short)j; break; }
+    }
+
+    str = vwm_json_str(settings, "hostname_bg", NULL);
+    if(str != NULL)
+    {
+        int j;
+        for(j = 0; j < 16; j++)
+            if(strcmp(str, vwm_color_names[j]) == 0)
+            { vwm->hostname_bg = (short)j; break; }
+    }
+
     /* per-desktop colors and wallpapers -- both stored as string arrays
        (color and pattern names).  Missing or malformed entries keep
        whatever vwm_init seeded.  Unknown names also keep the default. */
@@ -297,6 +321,21 @@ vwm_settings_save_general(vwm_t *vwm)
             idx = VWM_CLIPBOARD_NEVER;
         cJSON_AddStringToObject(settings, "clipboard",
             vwm_clipboard_mode_names[idx]);
+    }
+
+    cJSON_AddNumberToObject(settings, "show_hostname",
+        vwm->show_hostname ? 1 : 0);
+    {
+        int idx = vwm->hostname_fg;
+        if(idx < 0 || idx > 15) idx = COLOR_WHITE;
+        cJSON_AddStringToObject(settings, "hostname_fg",
+            vwm_color_names[idx]);
+    }
+    {
+        int idx = vwm->hostname_bg;
+        if(idx < 0 || idx > 15) idx = COLOR_BLUE;
+        cJSON_AddStringToObject(settings, "hostname_bg",
+            vwm_color_names[idx]);
     }
 
     /* persist the full VWM_MAX_DESKTOPS slot range so that shrinking

--- a/vwm.c
+++ b/vwm.c
@@ -244,6 +244,9 @@ vwm_init(void)
         vwm->screensaver_cmd[0] = '\0';
         vwm->screensaver_timeout = 0;
         vwm->clipboard_mode = VWM_CLIPBOARD_BOTH;
+        vwm->show_hostname = 0;             /* off by default */
+        vwm->hostname_fg = COLOR_WHITE;
+        vwm->hostname_bg = COLOR_BLUE;
         {
             /* sensible defaults per desktop -- diverse colors so a
                fresh vwm still has the original per-surface identity */


### PR DESCRIPTION
Add a host name shown in the desktop's bottom-left corner -- one column in from the left edge, with one blank row above the bottom status line. It is drawn in vwm_bkgd_simple_normal AFTER the wallpaper is blitted onto the surface canvas, so the wallpaper does not overpaint it, and on every desktop.

Two new Settings rows control it, both off/neutral by default:
  - "Show Hostname" -- a dropdown toggle (Off/On), default Off; also flips with Left/Right on the row.
  - "Hostname Colors" -- reuses the dual-swatch fg/bg picker, default White on Blue.

State lives in vwm_t (show_hostname / hostname_fg / hostname_bg), seeded off in vwm_init and persisted as JSON (show_hostname plus hostname_fg / hostname_bg color names) in settings.c.  NUM_BASE_SETTINGS goes 6 -> 8; the per-desktop color/wallpaper rows shift with it (persistence is by name-array, not index, so nothing breaks).  Like the desktop colors, the toggle and colors commit to vwm and persist on Save.  The label colors apply via wattr_set so bright (8-15) picks render correctly.