### PR TITLE
vwmterm: coalesce per-tile screen composites into one per scheduler step

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -108,7 +108,7 @@ MEDIUM IMPACT
        composites once instead of 2-3.  (Verified all switch(zone) cases
        break -- no early continue -- so the close is always painted.)
 
-[ ] 5. pt_thread.c refreshes per drain cycle, not per scheduler tick
+[x] 5. pt_thread.c refreshes per drain cycle, not per scheduler tick
        modules/vwmterm3/pt_thread.c lines 100-107
        Every vwmterm thread calls vk_screen_refresh whenever its own
        drain produced bytes.  With multiple busy vwmterms (split-screen
@@ -121,6 +121,28 @@ MEDIUM IMPACT
        after all threads have run, or (b) coalesce by checking whether
        any other tile is already redraw_pending and skip if so (the
        last one wins).
+
+       DONE (approach a): split the two concerns the drain path used to
+       fuse.  Each tile still renders its own window immediately
+       (vk_window_update, cheap), but instead of compositing the whole
+       screen it sets vwm->screen_dirty.  The scheduler grew a generic
+       per-step hook (vwm_sched_set_step_cb) -- it stays vdk-agnostic,
+       only invoking the callback after each step's dispatch -- and
+       vwm.c registers vwm_sched_render, which issues one
+       vk_screen_refresh per step when the flag is set, then clears it.
+       All ready tiles run inside a single protothread_run() per step,
+       so N busy tiles now cost one composite per step instead of N.
+       The hook is gated only by screen_dirty (not did_work), so the
+       deferred-refresh turn -- which deliberately doesn't report
+       did_work -- still composites in the same step.  Single-tile
+       behavior is unchanged (same refresh count, same step, just routed
+       through the hook); the startup composites and the terminal
+       close/EPIPE refresh paths are untouched.  Builds clean; module +
+       binary recompiled against the shared struct.  Branch
+       vwmterm-coalesce-refresh.  Verified interactively: htop, a caca
+       video (continuous high-rate output -- the heaviest coalescing
+       case), ps aux, and scrollback (the history-render branch) all
+       behaved normally; no stalls, tearing, or missed repaints.
 
 [ ] 6. vk_window_set_title called on no-op transitions
        modules/vwmterm3/events.c lines 300, 322, 403

--- a/modules/vwmterm3/pt_thread.c
+++ b/modules/vwmterm3/pt_thread.c
@@ -101,8 +101,12 @@ pt_t vwmterm_thd(void * const env)
         {
             if(vwmterm_data->redraw_pending)
             {
+                /* render this tile's own window now (cheap), but defer
+                   the screen composite: mark it dirty and let the
+                   scheduler's per-step hook coalesce every busy tile
+                   into a single vk_screen_refresh (item 5). */
                 vk_window_update(window);
-                vk_screen_refresh(vwm->screen);
+                vwm->screen_dirty = 1;
                 vwmterm_data->redraw_pending = 0;
             }
 

--- a/private.h
+++ b/private.h
@@ -43,6 +43,13 @@ struct _vwm_s
     vk_deck_t               **decks;
     vk_deck_t               *deck;
     int                     surface_count;
+
+    /* coalesced-refresh flag.  vterm drain tasks set this instead of
+       compositing per tile; the scheduler's per-step hook
+       (vwm_sched_render in vwm.c) issues one vk_screen_refresh per step
+       and clears it.  see modules/vwmterm3/pt_thread.c. */
+    int                     screen_dirty;
+
     vk_window_t             *menu;
     vk_menubar_t            *menubar;
     int                     menu_item_idx;

--- a/sched.c
+++ b/sched.c
@@ -56,6 +56,8 @@ struct _vwm_sched_s
 {
     protothread_t           pt_normal;
     protothread_t           pt_high;
+    vwm_sched_step_cb_t     step_cb;
+    void                    *step_cb_arg;
     vwm_sched_slot_t        slots[VWM_SCHED_MAX_TASKS];
 };
 
@@ -85,6 +87,15 @@ vwm_sched_deinit(vwm_sched_t *sched)
     protothread_free(sched->pt_high);
 
     free(sched);
+}
+
+void
+vwm_sched_set_step_cb(vwm_sched_t *sched, vwm_sched_step_cb_t cb, void *arg)
+{
+    if(sched == NULL) return;
+
+    sched->step_cb = cb;
+    sched->step_cb_arg = arg;
 }
 
 int
@@ -247,6 +258,15 @@ vwm_sched_run(vwm_sched_t *sched, int *shutdown)
                 }
             }
         }
+
+        /*
+            coalesced render hook.  every ready NORMAL task (the vterm
+            tiles) ran inside the protothread_run() calls above, each
+            updating only its own window; any that produced output marked
+            the screen dirty.  fire the hook once here so a step with N
+            busy tiles costs a single screen composite instead of N.
+        */
+        if(sched->step_cb != NULL) sched->step_cb(sched->step_cb_arg);
 
         sweep_pos++;
 

--- a/sched.h
+++ b/sched.h
@@ -91,6 +91,18 @@ int             vwm_sched_task_create(vwm_sched_t *sched,
 void            vwm_sched_run(vwm_sched_t *sched, int *shutdown);
 
 /*
+    optional per-step callback.  fired once at the end of every
+    scheduler step, after all ready tasks have run.  vwm uses it to
+    coalesce vterm screen composites: drain tasks mark the screen dirty
+    and the callback issues a single vk_screen_refresh per step instead
+    of one per busy tile.  pass cb = NULL to disable.  the scheduler
+    stays vdk-agnostic -- it only invokes the hook, it does not composite.
+*/
+typedef void    (*vwm_sched_step_cb_t)(void *arg);
+void            vwm_sched_set_step_cb(vwm_sched_t *sched,
+                    vwm_sched_step_cb_t cb, void *arg);
+
+/*
     number of slots currently in use (active tasks).  cheap O(N) scan
     of the ring; safe to call from anywhere on the main thread.
 */

--- a/vwm.c
+++ b/vwm.c
@@ -65,6 +65,9 @@ vwm_on_surface_change(vk_object_t *object, int event, void *anything);
 static int
 vwm_on_teleport(vk_object_t *object, int event, void *anything);
 
+static void
+vwm_sched_render(void *arg);
+
 vwm_sched_t             *sched = NULL;
 int                     shutdown = 0;
 
@@ -212,6 +215,10 @@ int main(int argc,char **argv)
 
     vk_screen_refresh(vwm->screen);
 
+    /* coalesce vterm composites: drain tasks mark the screen dirty and
+       this hook issues one refresh per scheduler step (see item 5). */
+    vwm_sched_set_step_cb(sched, vwm_sched_render, vwm);
+
     vwm_sched_run(sched, &shutdown);
 
     vwm_sched_deinit(sched);
@@ -222,6 +229,25 @@ int main(int argc,char **argv)
 	close(fd);
 
 	return 0;
+}
+
+/*
+    scheduler per-step render hook.  the vterm drain tasks update their
+    own windows and set vwm->screen_dirty rather than each compositing
+    the whole screen; this fires once per step and collapses N busy
+    tiles into a single vk_screen_refresh.  cheap no-op when nothing
+    drained this step.
+*/
+static void
+vwm_sched_render(void *arg)
+{
+    vwm_t   *vwm = (vwm_t *)arg;
+
+    if(vwm->screen_dirty)
+    {
+        vk_screen_refresh(vwm->screen);
+        vwm->screen_dirty = 0;
+    }
 }
 
 vwm_t*


### PR DESCRIPTION
Each busy vwmterm tile called vk_screen_refresh on every drain, so N busy tiles cost N full-screen composites per scheduler step (e.g. a caca video beside htop). Split the drain path: each tile still renders its own window with vk_window_update but sets vwm->screen_dirty instead of compositing the whole screen. A generic per-step scheduler hook (vwm_sched_set_step_cb) then issues a single vk_screen_refresh per step when the flag is set. The scheduler stays vdk-agnostic -- it only invokes the hook, it does not composite.

Verified interactively: htop, a caca video, ps aux, and scrollback all render normally with no stalls or missed repaints.