### PR TITLE
vwmterm: scroll back through less than one screenful of history

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,14 @@
+Version 4.8.0
+
+*  [Bryan Christ] vwmterm scrollback now reveals less than one screenful of
+   history.  Scrolling back into a short capture -- fewer lines than the
+   window is tall, e.g. a brief `ls -l` -- previously did nothing, because
+   the render clamped to whole screens of evicted rows.  It now composes the
+   scrolled-back history above the live screen (via libvterm's new
+   vterm_wnd_scrollback), so the wheel, Alt+PgUp/PgDn, and the bar all reach
+   the very first captured line the way a hardware terminal scrolls back.
+   Requires libvterm 10.4+.
+
 Version 4.7.0
 
 *  [Bryan Christ] vwmterm scrollbar.  Bordered terminal windows show a

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,17 @@
 2026-07-01
 
+Terminal scrollback now shows short histories too.  Scrolling back through
+output that only slightly overflowed the window -- fewer lines than the
+terminal is tall, like a quick `ls -l` -- used to do nothing; now the wheel,
+Alt+PgUp / Alt+PgDn, and the scrollbar reveal those lines above the live
+screen, just like a hardware terminal, all the way to the first line
+captured.
+
+Building this release needs libvterm 10.4+ and libviper 5.4.0+.
+
+
+2026-07-01
+
 Terminal windows now have a scrollbar.  A bordered vwmterm shows a vertical
 bar down its right edge whose thumb reflects how much scrollback you have --
 full when there is nothing to scroll, shrinking as history builds, and

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ CMake
 ncursesw 5.4+
 libviper 5.4.0+  - https://github.com/TragicWarrior/libviper
 libgpm (optional)
-libvterm 10.3+ - https://github.com/TragicWarrior/libvterm
+libvterm 10.4+ - https://github.com/TragicWarrior/libvterm
 FreeType         (for the screen-capture module; "make all")
 libcups2-dev     (for the print module; "make all")
 zlib             (for the big-font hostname module, vwmfont)

--- a/modules/vwmterm3/events.c
+++ b/modules/vwmterm3/events.c
@@ -381,25 +381,20 @@ vwmterm_window_update(vwmterm_data_t *vwmterm_data)
 }
 
 /*
-    Render the vterm at the current scroll_offset: the history buffer when
-    scrolled back, the live buffer at the bottom.  Same offset math the wheel
-    and Alt+PgUp paths use.
+    Render the vterm at the current scroll_offset.  scroll_offset is the
+    scroll-back distance in rows; libvterm's vterm_wnd_scrollback composes the
+    newest N evicted rows above the head of the live screen -- so even less
+    than one screenful of history shows, with the live buffer beneath it.
+    scroll_offset 0 is the live buffer (drawn with the cursor).
 */
 static void
 vwmterm_scroll_render(vwmterm_data_t *vwmterm_data)
 {
     vterm_t     *vterm = vwmterm_data->vterm;
-    int         width, height;
-    int         history_sz;
-    int         offset;
 
     if(vwmterm_data->scroll_offset > 0)
     {
-        vwmterm_grid_size(vwmterm_data, &width, &height);
-        history_sz = vterm_get_history_size(vterm);
-        offset = history_sz - height - vwmterm_data->scroll_offset;
-        if(offset < 0) offset = 0;
-        vterm_wnd_update(vterm, VTERM_BUF_HISTORY, offset,
+        vterm_wnd_scrollback(vterm, vwmterm_data->scroll_offset,
             VTERM_WND_RENDER_ALL);
     }
     else
@@ -430,7 +425,7 @@ vwmterm_scrollbar_to(vwmterm_data_t *vwmterm_data, int row, int is_press)
     used = vterm_get_history_used(vterm);
 
     if(vterm_get_active_buffer(vterm) == VTERM_BUF_ALTERNATE) return;
-    if(used <= height) return;                  /* nothing scrolled off yet */
+    if(used <= 0) return;                       /* nothing scrolled off yet */
 
     if(is_press && row <= 0)
     {
@@ -446,12 +441,12 @@ vwmterm_scrollbar_to(vwmterm_data_t *vwmterm_data, int row, int is_press)
         if(row < 1) row = 1;
         if(row > height - 2) row = height - 2;
         p = row - 1;                            /* 0 .. track_len-1 */
-        scroll_range = used - height;
+        scroll_range = used;
         scroll_y = (track_len > 1) ? p * scroll_range / (track_len - 1) : 0;
-        new_offset = (used - height) - scroll_y;
+        new_offset = used - scroll_y;
     }
 
-    if(new_offset > used - height) new_offset = used - height;
+    if(new_offset > used) new_offset = used;
     if(new_offset < 0) new_offset = 0;
 
     if(new_offset == vwmterm_data->scroll_offset) return;
@@ -497,9 +492,7 @@ vwmterm_ON_KEYSTROKE(vk_object_t *object, int32_t keystroke)
     vwmterm_data_t  *vwmterm_data;
     vterm_t         *vterm;
     int             width, height;
-    int             history_sz;
     int             used;
-    int             offset;
 
     window = VK_WINDOW(object);
     vwm = vwm_get_instance();
@@ -650,8 +643,8 @@ vwmterm_ON_KEYSTROKE(vk_object_t *object, int32_t keystroke)
             used = vterm_get_history_used(vterm);
 
             vwmterm_data->scroll_offset += VWMTERM_WHEEL_SCROLL_LINES;
-            if(vwmterm_data->scroll_offset > used - height)
-                vwmterm_data->scroll_offset = used - height;
+            if(vwmterm_data->scroll_offset > used)
+                vwmterm_data->scroll_offset = used;
             if(vwmterm_data->scroll_offset < 0)
                 vwmterm_data->scroll_offset = 0;
 
@@ -672,9 +665,6 @@ vwmterm_ON_KEYSTROKE(vk_object_t *object, int32_t keystroke)
 
             if(vwmterm_data->scroll_offset == 0) return KMIO_HANDLED;
 
-            vwmterm_grid_size(vwmterm_data, &width, &height);
-            history_sz = vterm_get_history_size(vterm);
-
             vwmterm_data->scroll_offset -= VWMTERM_WHEEL_SCROLL_LINES;
             if(vwmterm_data->scroll_offset <= 0)
             {
@@ -685,11 +675,7 @@ vwmterm_ON_KEYSTROKE(vk_object_t *object, int32_t keystroke)
                 return KMIO_HANDLED;
             }
 
-            offset = history_sz - height - vwmterm_data->scroll_offset;
-            if(offset < 0) offset = 0;
-
-            vterm_wnd_update(vterm, VTERM_BUF_HISTORY, offset,
-                VTERM_WND_RENDER_ALL);
+            vwmterm_scroll_render(vwmterm_data);
             vwmterm_window_update(vwmterm_data);
             vk_screen_refresh(vwm->screen);
 
@@ -789,8 +775,8 @@ vwmterm_ON_KEYSTROKE(vk_object_t *object, int32_t keystroke)
         used = vterm_get_history_used(vterm);
 
         vwmterm_data->scroll_offset += height;
-        if(vwmterm_data->scroll_offset > used - height)
-            vwmterm_data->scroll_offset = used - height;
+        if(vwmterm_data->scroll_offset > used)
+            vwmterm_data->scroll_offset = used;
         if(vwmterm_data->scroll_offset < 0)
             vwmterm_data->scroll_offset = 0;
 
@@ -809,7 +795,6 @@ vwmterm_ON_KEYSTROKE(vk_object_t *object, int32_t keystroke)
         if(vwmterm_data->scroll_offset == 0) return KMIO_HANDLED;
 
         vwmterm_grid_size(vwmterm_data, &width, &height);
-        history_sz = vterm_get_history_size(vterm);
 
         vwmterm_data->scroll_offset -= height;
         if(vwmterm_data->scroll_offset <= 0)
@@ -821,11 +806,7 @@ vwmterm_ON_KEYSTROKE(vk_object_t *object, int32_t keystroke)
             return KMIO_HANDLED;
         }
 
-        offset = history_sz - height - vwmterm_data->scroll_offset;
-        if(offset < 0) offset = 0;
-
-        vterm_wnd_update(vterm, VTERM_BUF_HISTORY, offset,
-            VTERM_WND_RENDER_ALL);
+        vwmterm_scroll_render(vwmterm_data);
         vwmterm_window_update(vwmterm_data);
         vk_screen_refresh(vwm->screen);
 

--- a/modules/vwmterm3/init.c
+++ b/modules/vwmterm3/init.c
@@ -115,13 +115,14 @@ vwmterm_scroll_info(vk_widget_t *source, int *content_h, int *content_w,
     vterm_wnd_size(vterm, &width, &height);
     used = vterm_get_history_used(vterm);
 
-    /* the scroller works in real-history coordinates: content = used rows,
-       visible window = height.  scroll position 0 = oldest (top), used-height
-       = live (bottom); scroll_offset counts back from live, so invert it. */
-    offset = (used - height) - vwmterm_data->scroll_offset;
+    /* the scroller's content is the scrollback (used rows) plus the live
+       screen (height rows); the viewport is height.  scroll position 0 =
+       oldest at top, used = live at the bottom.  scroll_offset counts back
+       from live, so the position is used - scroll_offset. */
+    offset = used - vwmterm_data->scroll_offset;
     if(offset < 0) offset = 0;
 
-    if(content_h != NULL) *content_h = used;
+    if(content_h != NULL) *content_h = used + height;
     if(scroll_y != NULL) *scroll_y = offset;
 }
 

--- a/modules/vwmterm3/pt_thread.c
+++ b/modules/vwmterm3/pt_thread.c
@@ -50,9 +50,6 @@ pt_t vwmterm_thd(void * const env)
     vterm_t             *vterm;
     ssize_t             bytes_read = 0;
     int                 i;
-    int                 history_sz;
-    int                 width, height;
-    int                 offset;
 
     vwm_sched_ctx_t     *ctx_vwmterm;
     vwmterm_data_t      *vwmterm_data;
@@ -83,11 +80,7 @@ pt_t vwmterm_thd(void * const env)
 
             if(vwmterm_data->scroll_offset > 0)
             {
-                vterm_wnd_size(vterm, &width, &height);
-                history_sz = vterm_get_history_size(vterm);
-                offset = history_sz - height - vwmterm_data->scroll_offset;
-                if(offset < 0) offset = 0;
-                vterm_wnd_update(vterm, VTERM_BUF_HISTORY, offset,
+                vterm_wnd_scrollback(vterm, vwmterm_data->scroll_offset,
                     VTERM_WND_RENDER_ALL);
             }
             else

--- a/vwm.h
+++ b/vwm.h
@@ -11,7 +11,7 @@
 #include <vkmio.h>
 
 
-#define VWM_VERSION					"4.7.0"
+#define VWM_VERSION					"4.8.0"
 
 /* the kmio feature set vwm arms at startup and must re-arm whenever the
    outer terminal may have changed under us -- teleport to a new PTY, a


### PR DESCRIPTION
Scrolling back into a short capture -- fewer lines than the window is tall, e.g. a brief `ls -l` -- did nothing: the render clamped to whole screens of evicted rows and the scroll clamps bailed at used <= height.

Render via libvterm's new vterm_wnd_scrollback(), which composes the scrolled-back history above the live screen, and relax every back-scroll clamp from used - height to used so the wheel, Alt+PgUp/PgDn, and the bar reach the first captured line.  The scroller's content is now the scrollback plus the live screen (used + height).  The inline BUTTON5 and PgDn renders route through vwmterm_scroll_render, retiring dead locals.

Requires libvterm 10.4+; bump to 4.8.0.