### PR TITLE
release: vwm 4.9.0

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,20 @@
+Version 4.9.0
+
+*  [Bryan Christ] Minimized windows.  A window's title bar gains a minimize
+   glyph (a down-arrow, "v" on non-UTF-8) left of [X] that hides it in place;
+   the top panel shows a "(N) Minimized" pulldown, next to VWM, that lists the
+   hidden windows and restores one on click.  The Alt+W manage-windows tool
+   gains Minimize and Restore buttons that act on the checked windows and
+   flags already-minimized rows with the same down-arrow.  Restoring a window
+   raises it and returns focus.  Requires libviper 5.5.0+.
+*  [Bryan Christ] Window focus decoration is now driven by libviper's
+   VK_EVENT_ON_FINALIZE deck event.  A single handler repaints the focus
+   borders whenever the deck's membership or stacking changes, replacing the
+   hand-rolled "demote the old top, promote the new top" logic that was
+   duplicated across raise, cycle, close, minimize, restore, cross-desktop
+   move, and window spawn.  Border changes are immediate and can no longer
+   fall out of sync.
+
 Version 4.8.0
 
 *  [Bryan Christ] vwmterm scrollback now reveals less than one screenful of

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,17 @@
 2026-07-01
 
+Windows can be minimized.  Click the down-arrow on a window's title bar (just
+left of the close box) to tuck it out of the way; the top panel shows a
+"(N) Minimized" button next to VWM that drops down the list of hidden windows,
+and clicking one brings it back on top with focus.  The Alt+W window manager
+also gains Minimize and Restore buttons that act on whichever windows you have
+checked, and marks the rows that are already minimized with the same arrow.
+
+Building this release needs libvterm 10.4+ and libviper 5.5.0+.
+
+
+2026-07-01
+
 Terminal scrollback now shows short histories too.  Scrolling back through
 output that only slightly overflowed the window -- fewer lines than the
 terminal is tall, like a quick `ls -l` -- used to do nothing; now the wheel,

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ REQUIREMENTS
 
 CMake
 ncursesw 5.4+
-libviper 5.4.0+  - https://github.com/TragicWarrior/libviper
+libviper 5.5.0+  - https://github.com/TragicWarrior/libviper
 libgpm (optional)
 libvterm 10.4+ - https://github.com/TragicWarrior/libvterm
 FreeType         (for the screen-capture module; "make all")

--- a/bkgd.c
+++ b/bkgd.c
@@ -66,6 +66,14 @@ _bkgd_has_utf8(void)
     return cached != 0;
 }
 
+/* public wrapper so other modules (e.g. the window decorator) can pick
+   UTF-8 vs ASCII glyphs off the same cached check */
+bool
+vwm_has_utf8(void)
+{
+    return _bkgd_has_utf8();
+}
+
 const char *vwm_wallpaper_names[VWM_WALLPAPER_COUNT] =
 {
     "None",

--- a/bkgd.h
+++ b/bkgd.h
@@ -15,4 +15,6 @@ void    vwm_invalidate_wallpaper_cache(int surface_id);
 void    vwm_invalidate_wallpaper_cache_all(void);
 void    vwm_invalidate_wallpaper_cache_all_orphan(void);
 
+bool    vwm_has_utf8(void);
+
 #endif

--- a/launch_picker.c
+++ b/launch_picker.c
@@ -166,11 +166,9 @@ launch_picker_launch(const char *fullpath)
     window = module->main(module);
     if(window != NULL)
     {
-        vk_widget_t *old_top = vk_deck_get_top(vwm->deck);
-
+        /* add at top; ON_FINALIZE decorates the new window as focused and
+           demotes the previous top */
         vk_deck_add_widget(vwm->deck, VK_WIDGET(window), VK_DECK_TOP);
-        if(old_top != NULL) vk_window_update(VK_WINDOW(old_top));
-        vk_window_update(window);
         vk_screen_refresh(vwm->screen);
     }
 }

--- a/mainmenu.c
+++ b/mainmenu.c
@@ -36,6 +36,7 @@
 #include "manage_settings.h"
 #include "manage_windows.h"
 #include "screensaver.h"
+#include "winman.h"
 
 /* Has BUTTON1_PRESSED landed inside the open dropdown since it opened?
    The menubar opens the dropdown on its OWN press, and the matching
@@ -177,6 +178,20 @@ vwm_apps_menu_activate(vk_widget_t *widget, void *anything)
 
     vwm = vwm_get_instance();
     open_dropdown(vwm, 0);
+
+    return 0;
+}
+
+static int
+vwm_minimized_menu_activate(vk_widget_t *widget, void *anything)
+{
+    vwm_t   *vwm;
+
+    (void)widget;
+    (void)anything;
+
+    vwm = vwm_get_instance();
+    open_dropdown(vwm, 2);
 
     return 0;
 }
@@ -371,6 +386,85 @@ create_apps_dropdown(vwm_t *vwm)
     return window;
 }
 
+static int
+vwm_restore_minimized(vk_widget_t *widget, void *anything)
+{
+    (void)widget;
+
+    if(anything != NULL) vwm_restore_window(VK_WIDGET(anything));
+
+    return 0;
+}
+
+static vk_window_t*
+create_minimized_dropdown(vwm_t *vwm)
+{
+    vk_listbox_t    *listbox;
+    vk_window_t     *window;
+    vk_widget_t     *w;
+    const char      *title;
+    const char      *caption = " Minimized ";
+    char            buf[NAME_MAX];
+    int             max_width = 0;
+    int             max_height = 0;
+    int             scr_width, scr_height;
+    int             count, i;
+    int             shown = 0;
+
+    getmaxyx(vk_screen_get_window(vwm->screen), scr_height, scr_width);
+    scr_width -= 4;
+    scr_height = (scr_height * 3) / 4;
+
+    listbox = vk_listbox_create(8, 10);
+    vk_widget_set_colors(VK_WIDGET(listbox), COLOR_WHITE, COLOR_CYAN);
+    vk_widget_set_attrs(VK_WIDGET(listbox), A_BOLD);
+    vk_listbox_set_highlight(listbox, COLOR_WHITE, COLOR_BLACK);
+    vk_listbox_set_highlight_attrs(listbox, A_BOLD);
+    vk_listbox_set_wrap(listbox, TRUE);
+    vk_object_set_kmio(VK_OBJECT(listbox), vwm_dropdown_kmio);
+
+    count = vk_deck_count(vwm->deck);
+    for(i = 0; i < count; i++)
+    {
+        w = vk_deck_get_widget(vwm->deck, i);
+        if(w == NULL) continue;
+        if(vk_widget_get_state(w) & VK_STATE_VISIBLE) continue;  /* only hidden */
+
+        title = vk_window_get_title(VK_WINDOW(w));
+        if(title == NULL || title[0] == '\0') title = "(untitled)";
+
+        snprintf(buf, sizeof(buf), "%s", title);
+        vk_listbox_add_item(listbox, buf, vwm_restore_minimized, w);
+        shown++;
+    }
+
+    if(shown == 0)
+        vk_listbox_add_item(listbox, "(none)", NULL, NULL);
+
+    vk_listbox_update(listbox);
+    vk_listbox_get_metrics(listbox, &max_width, &max_height);
+    max_width += 4;
+    /* vk_window centers the caption and truncates it to (window width - 4);
+       window width is max_width + 2, so the usable title span is max_width - 2.
+       Floor to strlen(caption) + 2 or a short app list (e.g. "htop") clips the
+       caption's trailing space against the right frame. */
+    if(max_width < (int)strlen(caption) + 2)
+        max_width = (int)strlen(caption) + 2;
+    if(max_width > scr_width) max_width = scr_width;
+    if(max_height > scr_height) max_height = scr_height;
+
+    vk_widget_resize(VK_WIDGET(listbox), max_width, max_height);
+
+    window = vk_window_create(max_width + 2, max_height + 2);
+    vk_window_set_title(window, caption);
+    vk_window_set_border_style(window, VK_BORDER_SINGLE);
+    vk_window_set_border_colors(window, COLOR_WHITE, COLOR_CYAN);
+    vk_window_set_border_attrs(window, A_BOLD);
+    vk_window_set_child(window, VK_WIDGET(listbox));
+
+    return window;
+}
+
 static void
 open_dropdown(vwm_t *vwm, int idx)
 {
@@ -382,6 +476,8 @@ open_dropdown(vwm_t *vwm, int idx)
 
     if(idx == 0)
         window = create_apps_dropdown(vwm);
+    else if(idx == 2)
+        window = create_minimized_dropdown(vwm);
     else
         window = create_file_dropdown(vwm);
 
@@ -495,12 +591,14 @@ vwm_menubar_init(void)
         vwm_apps_menu_activate, NULL);
     vk_menubar_add_item(vwm->menubar, "VWM",
         vwm_file_menu_activate, NULL);
+    vk_menubar_add_item(vwm->menubar, "(0) Minimized",
+        vwm_minimized_menu_activate, NULL);
 
     vk_object_register_event(VK_OBJECT(vwm->menubar),
         VK_EVENT_ON_SELECT, vwm_menubar_on_select, NULL);
 
-    // " Apps " + "|" + " VWM " = 6 + 1 + 5 = 12
-    menubar_width = 12;
+    // " Apps " + "|" + " VWM " + "|" + " (99) Minimized " = 6+1+5+1+16 = 29
+    menubar_width = 29;
     vk_widget_resize(VK_WIDGET(vwm->menubar), menubar_width, 1);
 
     vk_menubar_update(vwm->menubar);
@@ -512,6 +610,40 @@ vwm_menubar_init(void)
     }
 
     vwm->menu_item_idx = -1;
+}
+
+/*
+    Recount the minimized (hidden) windows and update the "(N) Minimized"
+    menu-bar item, then repaint the panel row.  Called whenever a window is
+    minimized or restored.
+*/
+void
+vwm_minimized_refresh(void)
+{
+    vwm_t       *vwm;
+    vk_widget_t *w;
+    char        label[32];
+    int         count, i, n = 0;
+
+    vwm = vwm_get_instance();
+    if(vwm == NULL || vwm->menubar == NULL) return;
+
+    count = vk_deck_count(vwm->deck);
+    for(i = 0; i < count; i++)
+    {
+        w = vk_deck_get_widget(vwm->deck, i);
+        if(w == NULL) continue;
+        if(!(vk_widget_get_state(w) & VK_STATE_VISIBLE)) n++;
+    }
+
+    snprintf(label, sizeof(label), "(%d) Minimized", n);
+    vk_menubar_set_item_label(vwm->menubar, 2, label);
+
+    {
+        VWM_PANEL *panel = vwm_panel_get_data();
+        vk_box_update(panel->box);
+        vk_widget_draw(VK_WIDGET(panel->box));
+    }
 }
 
 int

--- a/mainmenu.h
+++ b/mainmenu.h
@@ -10,5 +10,6 @@ int             vwm_menubar_hotkey(void);
 void            vwm_menubar_close_dropdown(void);
 int             vwm_menubar_ON_KEYSTROKE(int32_t keystroke);
 int             vwm_dropdown_mouse(MEVENT *mouse_event);
+void            vwm_minimized_refresh(void);
 
 #endif

--- a/manage_windows.c
+++ b/manage_windows.c
@@ -10,6 +10,7 @@
 #include "vwm.h"
 #include "private.h"
 #include "winman.h"
+#include "bkgd.h"
 #include "panel.h"
 #include "manage_windows.h"
 #include "manage_ui_common.h"
@@ -22,7 +23,7 @@
 
 #define MANAGE_WINDOWS_HELP \
     "Space/click checks windows.  Tab cycles fields.  " \
-    "Close/Move Selected act on every checked window."
+    "Close/Move/Minimize/Restore act on the checked windows."
 
 #define WARNING_LINE_2  "Any unsaved work will be lost."
 
@@ -30,6 +31,8 @@ enum
 {
     BTN_CLOSE = 0,
     BTN_MOVE_TO,
+    BTN_MINIMIZE,
+    BTN_RESTORE,
     BTN_CANCEL,
     NUM_BUTTONS
 };
@@ -39,6 +42,8 @@ enum
     FOCUS_LIST = 0,
     FOCUS_BTN_CLOSE,
     FOCUS_BTN_MOVE_TO,
+    FOCUS_BTN_MINIMIZE,
+    FOCUS_BTN_RESTORE,
     FOCUS_BTN_CANCEL,
     FOCUS_MAX
 };
@@ -112,7 +117,11 @@ static void     move_apply(void);
 
 static void     on_close(void);
 static void     on_move_to(void);
+static void     on_minimize(void);
+static void     on_restore(void);
 static void     on_cancel(void);
+static void     do_minimize_selected(void);
+static void     do_restore_selected(void);
 
 
 /* ── listbox helpers ───────────────────────────────────────── */
@@ -186,6 +195,8 @@ rebuild_listbox(void)
 
     for(i = 0; i < count; i++)
     {
+        const char  *mark;
+
         w = vk_deck_get_widget(vwm->deck, i);
         if(w == NULL) continue;
 
@@ -193,7 +204,15 @@ rebuild_listbox(void)
         if(title == NULL || title[0] == '\0')
             title = "(untitled)";
 
-        snprintf(label, sizeof(label), "%s", title);
+        /* flag minimized (hidden) windows with a down-arrow.  every row gets
+           a one-column marker slot -- a space when the window is visible --
+           so the titles stay aligned whether or not the row is minimized */
+        if(!(vk_widget_get_state(w) & VK_STATE_VISIBLE))
+            mark = vwm_has_utf8() ? "\xe2\x86\x93" : "v";   /* U+2193 down arrow */
+        else
+            mark = " ";
+
+        snprintf(label, sizeof(label), "%s %s", mark, title);
         vk_selectbox_add_item(windows_selectbox, label, NULL, NULL);
     }
 
@@ -277,6 +296,37 @@ on_cancel(void)
     vwm_manage_windows_close();
 }
 
+/*
+    Minimize/Restore are non-destructive, so -- unlike Close and Move -- they
+    act immediately and leave the tool open.  The window list refreshes in
+    place so the down-arrow markers update and you can minimize/restore more.
+*/
+static void
+on_minimize(void)
+{
+    if(count_checked() == 0)
+    {
+        error_popup_open();
+        return;
+    }
+
+    do_minimize_selected();
+    refresh_dialog();
+}
+
+static void
+on_restore(void)
+{
+    if(count_checked() == 0)
+    {
+        error_popup_open();
+        return;
+    }
+
+    do_restore_selected();
+    refresh_dialog();
+}
+
 static void
 do_close_selected(void)
 {
@@ -314,6 +364,58 @@ do_close_selected(void)
         if(curr >= list_count)
             vk_selectbox_set_curr(windows_selectbox, list_count - 1);
     }
+}
+
+/*
+    minimize/restore every checked window.  unlike close/move these do NOT
+    change deck membership (minimized windows stay in the deck, just hidden),
+    so the row->deck index mapping is stable -- but we still snapshot first to
+    mirror the close/move pattern, then rebuild the list to refresh the
+    down-arrow markers.  the cursor row is clamped in case it drifted.
+*/
+static void
+do_minimize_restore_selected(bool restore)
+{
+    vk_widget_t **checked;
+    int          n, i;
+
+    n = count_checked();
+    if(n == 0) return;
+
+    checked = malloc((size_t)n * sizeof(vk_widget_t *));
+    if(checked == NULL) return;
+
+    n = collect_checked(checked, n);
+
+    for(i = 0; i < n; i++)
+    {
+        if(restore)
+            vwm_restore_window(checked[i]);
+        else
+            vwm_minimize_window(checked[i]);
+    }
+
+    free(checked);
+
+    rebuild_listbox();
+    if(list_count > 0)
+    {
+        int curr = vk_selectbox_get_curr(windows_selectbox);
+        if(curr >= list_count)
+            vk_selectbox_set_curr(windows_selectbox, list_count - 1);
+    }
+}
+
+static void
+do_minimize_selected(void)
+{
+    do_minimize_restore_selected(false);
+}
+
+static void
+do_restore_selected(void)
+{
+    do_minimize_restore_selected(true);
 }
 
 
@@ -639,19 +741,9 @@ move_apply(void)
     free(checked);
 
     /*
-        if the focused (top) window was among those moved away, the
-        active deck's new top is left un-decorated as focused -- we used
-        the raw deck remove, not vwm_default_WINDOW_CLOSE.  Re-focus the
-        new top the same way WINDOW_CLOSE does so the desktop isn't left
-        with nothing in focus.
-    */
-    {
-        vk_widget_t *new_top = vk_deck_get_top(vwm->decks[active_surface]);
-        if(new_top != NULL)
-            vk_window_update(VK_WINDOW(new_top));
-    }
+        the raw deck remove/add above each fire ON_FINALIZE, so the active
+        deck's new top is already re-decorated -- no manual re-focus needed.
 
-    /*
         the active deck shrank -- rebuild the selectbox and clamp the
         cursor row.
     */
@@ -845,9 +937,11 @@ press_focused_button(void)
 {
     switch(focus_zone)
     {
-        case FOCUS_BTN_CLOSE:    on_close();   break;
-        case FOCUS_BTN_MOVE_TO:  on_move_to(); break;
-        case FOCUS_BTN_CANCEL:   on_cancel();  break;
+        case FOCUS_BTN_CLOSE:     on_close();    break;
+        case FOCUS_BTN_MOVE_TO:   on_move_to();  break;
+        case FOCUS_BTN_MINIMIZE:  on_minimize(); break;
+        case FOCUS_BTN_RESTORE:   on_restore();  break;
+        case FOCUS_BTN_CANCEL:    on_cancel();   break;
     }
 }
 
@@ -1009,12 +1103,17 @@ build_dialog(void)
         listbox_scroller);
 
     button_hbox = vk_box_create(INTERIOR_WIDTH, 3,
-        VK_BOX_HORIZONTAL, 4);
+        VK_BOX_HORIZONTAL, 6);
     vk_box_set_homogeneous(button_hbox, false);
     vk_widget_set_colors(VK_WIDGET(button_hbox), COLOR_BLACK, COLOR_CYAN);
 
-    buttons[BTN_CLOSE]    = vk_button_create("Close Selected");
-    buttons[BTN_MOVE_TO]  = vk_button_create("Move Selected");
+    /* bare verbs -- five buttons + a spacer pack exactly into the 46-col
+       interior; longer "... Selected" labels would overflow.  the checkbox
+       list and help line carry the "acts on every checked window" meaning */
+    buttons[BTN_CLOSE]    = vk_button_create("Close");
+    buttons[BTN_MOVE_TO]  = vk_button_create("Move");
+    buttons[BTN_MINIMIZE] = vk_button_create("Minimize");
+    buttons[BTN_RESTORE]  = vk_button_create("Restore");
     buttons[BTN_CANCEL]   = vk_button_create("Cancel");
 
     for(i = 0; i < NUM_BUTTONS; i++)
@@ -1033,8 +1132,10 @@ build_dialog(void)
 
     vk_box_set_widget(button_hbox, 0, VK_WIDGET(buttons[BTN_CLOSE]));
     vk_box_set_widget(button_hbox, 1, VK_WIDGET(buttons[BTN_MOVE_TO]));
-    vk_box_set_widget(button_hbox, 2, VK_WIDGET(button_spacer));
-    vk_box_set_widget(button_hbox, 3, VK_WIDGET(buttons[BTN_CANCEL]));
+    vk_box_set_widget(button_hbox, 2, VK_WIDGET(buttons[BTN_MINIMIZE]));
+    vk_box_set_widget(button_hbox, 3, VK_WIDGET(buttons[BTN_RESTORE]));
+    vk_box_set_widget(button_hbox, 4, VK_WIDGET(button_spacer));
+    vk_box_set_widget(button_hbox, 5, VK_WIDGET(buttons[BTN_CANCEL]));
 
     vk_box_set_widget(main_vbox, 0, VK_WIDGET(listbox_frame));
     vk_box_set_widget(main_vbox, 1, VK_WIDGET(button_hbox));
@@ -1307,25 +1408,39 @@ vwm_manage_windows_mouse(MEVENT *mouse_event)
     */
     if(rel_y >= wh - 4)
     {
-        /* button bar:  Close Selected | Move Selected | <spacer> | Cancel */
+        /* button bar:  Close | Move | Minimize | Restore | <spacer> | Cancel
+           natural widths 7/6/10/9 pack from the left; Cancel (8) is right-
+           aligned past a 6-col spacer -- see build_dialog for the layout */
         int interior_x = rel_x - 1;     /* skip left border */
 
         if(!(mouse_event->bstate & (BUTTON1_CLICKED | BUTTON1_RELEASED)))
             return 0;
 
-        if(interior_x < 16)             /* "Close Selected" ~16 wide */
+        if(interior_x < 7)                          /* Close    cols 0..6  */
         {
             focus_zone = FOCUS_BTN_CLOSE;
             update_button_highlights();
             on_close();
         }
-        else if(interior_x < 35)        /* "Move Selected" + gap */
+        else if(interior_x < 13)                    /* Move     cols 7..12 */
         {
             focus_zone = FOCUS_BTN_MOVE_TO;
             update_button_highlights();
             on_move_to();
         }
-        else if(interior_x >= INTERIOR_WIDTH - 8)   /* "Cancel" right-aligned */
+        else if(interior_x < 23)                    /* Minimize cols 13..22 */
+        {
+            focus_zone = FOCUS_BTN_MINIMIZE;
+            update_button_highlights();
+            on_minimize();
+        }
+        else if(interior_x < 32)                    /* Restore  cols 23..31 */
+        {
+            focus_zone = FOCUS_BTN_RESTORE;
+            update_button_highlights();
+            on_restore();
+        }
+        else if(interior_x >= INTERIOR_WIDTH - 8)   /* Cancel   cols 38..45 */
         {
             focus_zone = FOCUS_BTN_CANCEL;
             update_button_highlights();

--- a/modules.c
+++ b/modules.c
@@ -487,14 +487,9 @@ vwm_menu_helper(vk_widget_t *widget, void *anything)
 
     if(window != NULL)
     {
-        vk_widget_t *old_top = vk_deck_get_top(vwm->deck);
-
+        /* add at top; ON_FINALIZE decorates the new window as focused and
+           demotes the previous top */
         vk_deck_add_widget(vwm->deck, VK_WIDGET(window), VK_DECK_TOP);
-
-        if(old_top != NULL)
-            vk_window_update(VK_WINDOW(old_top));
-
-        vk_window_update(window);
         vk_screen_refresh(vwm->screen);
     }
 

--- a/poll_input_thd.c
+++ b/poll_input_thd.c
@@ -36,6 +36,7 @@ enum
     ZONE_MANAGE_SETTINGS,
     ZONE_STATUS_BAR,
     ZONE_CLOSE_BTN,
+    ZONE_MINIMIZE_BTN,
     ZONE_RESIZE_CORNER,
     ZONE_FRAME,
     ZONE_CONTENT,
@@ -217,6 +218,9 @@ classify_mouse(vwm_t *vwm, int mx, int my, vk_widget_t **hit_out)
     if(ry == 0 && rx >= ww - (int)sizeof("[X]") + 1 && rx < ww)
         return ZONE_CLOSE_BTN;
 
+    if(ry == 0 && rx == ww - (int)sizeof("[X]"))
+        return ZONE_MINIMIZE_BTN;
+
     state = vk_widget_get_state(hit);
     if(ry == wh - 1 && rx == ww - 1 && !(state & VK_STATE_NORESIZE))
         return ZONE_RESIZE_CORNER;
@@ -230,14 +234,11 @@ classify_mouse(vwm_t *vwm, int mx, int my, vk_widget_t **hit_out)
 static void
 raise_to_top(vwm_t *vwm, vk_widget_t *widget)
 {
-    vk_widget_t *old_top;
-
     if(widget == vk_deck_get_top(vwm->deck)) return;
 
-    old_top = vk_deck_get_top(vwm->deck);
+    /* set_top fires ON_FINALIZE, which repaints the outgoing and incoming
+       top windows -- no manual re-decoration needed */
     vk_deck_set_top(vwm->deck, widget);
-    if(old_top != NULL) vk_window_update(VK_WINDOW(old_top));
-    vk_window_update(VK_WINDOW(widget));
 }
 
 /*
@@ -601,6 +602,14 @@ vwm_poll_input(void * const env)
                         raise_to_top(vwm, hit);
                         vwm_default_WINDOW_CLOSE(hit);
                     }
+
+                    break;
+                }
+
+                case ZONE_MINIMIZE_BTN:
+                {
+                    if(bs & (BUTTON1_CLICKED | BUTTON1_PRESSED))
+                        vwm_minimize_window(hit);
 
                     break;
                 }

--- a/private.c
+++ b/private.c
@@ -103,6 +103,17 @@ vwm_window_decorate(vk_window_t *window, WINDOW *canvas, void *anything)
 
     mvwprintw(canvas, 0, x - (int)sizeof("[X]") + 1, "[X]");
 
+    /* minimize glyph, one column left of [X]: a down arrow (v on non-UTF-8) */
+    if(vwm_has_utf8())
+    {
+        wch[0] = 0x2193;                        /* U+2193 DOWNWARDS ARROW */
+        wch[1] = L'\0';
+        setcchar(&cc, wch, extra, pair, NULL);
+        mvwadd_wch(canvas, 0, x - (int)sizeof("[X]"), &cc);
+    }
+    else
+        mvwaddch(canvas, 0, x - (int)sizeof("[X]"), 'v');
+
     snprintf(buf, sizeof(buf), "[%d x %d]", x - 2 - reserved, y - 2);
     len = strlen(buf);
     mvwprintw(canvas, y - 1, (x / 2) - (len / 2), "%s", buf);

--- a/vwm.c
+++ b/vwm.c
@@ -297,16 +297,22 @@ vwm_init(void)
         vwm->decks[0] = vk_deck_create();
         vk_deck_set_shadow(vwm->decks[0], true);
         vk_screen_attach_widget(vwm->screen, 0, VK_WIDGET(vwm->decks[0]));
+        vk_object_register_event(VK_OBJECT(vwm->decks[0]),
+            VK_EVENT_ON_FINALIZE, vwm_on_deck_finalize, NULL);
 
         vk_screen_add_surface(vwm->screen);
         vwm->decks[1] = vk_deck_create();
         vk_deck_set_shadow(vwm->decks[1], true);
         vk_screen_attach_widget(vwm->screen, 1, VK_WIDGET(vwm->decks[1]));
+        vk_object_register_event(VK_OBJECT(vwm->decks[1]),
+            VK_EVENT_ON_FINALIZE, vwm_on_deck_finalize, NULL);
 
         vk_screen_add_surface(vwm->screen);
         vwm->decks[2] = vk_deck_create();
         vk_deck_set_shadow(vwm->decks[2], true);
         vk_screen_attach_widget(vwm->screen, 2, VK_WIDGET(vwm->decks[2]));
+        vk_object_register_event(VK_OBJECT(vwm->decks[2]),
+            VK_EVENT_ON_FINALIZE, vwm_on_deck_finalize, NULL);
 
         vwm->deck = vwm->decks[0];
 
@@ -384,6 +390,8 @@ vwm_apply_surface_count(int new_count)
             vk_deck_set_shadow(vwm->decks[i], true);
             vk_screen_attach_widget(vwm->screen, i,
                 VK_WIDGET(vwm->decks[i]));
+            vk_object_register_event(VK_OBJECT(vwm->decks[i]),
+                VK_EVENT_ON_FINALIZE, vwm_on_deck_finalize, NULL);
         }
 
         vwm->surface_count = new_count;
@@ -399,9 +407,9 @@ vwm_apply_surface_count(int new_count)
 
     for(i = old_count - 1; i >= new_count; i--)
     {
-        while(vk_deck_get_top(vwm->decks[i]) != NULL)
+        while(vk_deck_get_widget(vwm->decks[i], 0) != NULL)
         {
-            vk_widget_t *w = vk_deck_get_top(vwm->decks[i]);
+            vk_widget_t *w = vk_deck_get_widget(vwm->decks[i], 0);
             vk_deck_remove_widget(vwm->decks[i], w);
             vk_deck_add_widget(vwm->decks[target], w, VK_DECK_BOTTOM);
         }
@@ -473,6 +481,9 @@ vwm_on_surface_change(vk_object_t *object, int event, void *anything)
             if(w != NULL) vk_window_update(VK_WINDOW(w));
         }
     }
+
+    /* the "(N) Minimized" count is per-desktop -- recount for the new deck */
+    vwm_minimized_refresh();
 
     return 0;
 }

--- a/vwm.h
+++ b/vwm.h
@@ -11,7 +11,7 @@
 #include <vkmio.h>
 
 
-#define VWM_VERSION					"4.8.0"
+#define VWM_VERSION					"4.9.0"
 
 /* the kmio feature set vwm arms at startup and must re-arm whenever the
    outer terminal may have changed under us -- teleport to a new PTY, a

--- a/winman.c
+++ b/winman.c
@@ -67,44 +67,120 @@ vwm_default_VWM_STOP(void)
     flash();
 }
 
+/*
+    VK_EVENT_ON_FINALIZE handler, registered on every deck.  The deck's
+    membership or stacking just changed, so repaint each member's decoration.
+    A window's decorator recolors it from vk_deck_get_top(), so a plain
+    vk_window_update() per member is all it takes to keep the focus borders
+    correct -- no call site has to demote the old top and promote the new one
+    by hand.  Decoration ONLY: this never calls vk_screen_refresh(); the
+    operation that changed the deck owns the single refresh.
+*/
+int
+vwm_on_deck_finalize(vk_object_t *object, int event, void *anything)
+{
+    vk_deck_t   *deck;
+    int          i, n;
+
+    (void)event;
+    (void)anything;
+
+    deck = VK_DECK(object);
+    if(deck == NULL) return 0;
+
+    n = vk_deck_count(deck);
+    for(i = 0; i < n; i++)
+    {
+        vk_widget_t *w = vk_deck_get_widget(deck, i);
+        if(w != NULL) vk_window_update(VK_WINDOW(w));
+    }
+
+    return 0;
+}
+
 void
 vwm_default_WINDOW_CLOSE(vk_widget_t *widget)
 {
-    vwm_t       *vwm;
-    vk_widget_t *new_top;
+    vwm_t   *vwm;
 
     if(widget == NULL) return;
 
     vwm = vwm_get_instance();
 
     vk_object_emit(VK_OBJECT(widget), VWM_EVENT_ON_CLOSE);
+
+    /* removing the widget fires ON_FINALIZE, which re-decorates whatever
+       window is now on top -- no manual focus hand-off needed here */
     vk_deck_remove_widget(vwm->deck, widget);
     vk_widget_destroy(widget);
 
-    new_top = vk_deck_get_top(vwm->deck);
-    if(new_top != NULL)
-        vk_window_update(VK_WINDOW(new_top));
-    else
+    if(vk_deck_get_top(vwm->deck) == NULL)
         vwm_panel_set_status("Press Alt ~ for Menu");
 
+    vwm_minimized_refresh();
+    vk_screen_refresh(vwm->screen);
+}
+
+/*
+    Minimize a window: hide it in place (the deck blitter skips non-visible
+    members) and hand focus to the next visible window.  The window stays in
+    the deck -- the "(N) Minimized" panel item and the manage-windows tool
+    enumerate the hidden members and restore them.
+*/
+void
+vwm_minimize_window(vk_widget_t *widget)
+{
+    vwm_t   *vwm;
+
+    if(widget == NULL) return;
+
+    vwm = vwm_get_instance();
+
+    /* hiding a member isn't a deck mutation, so the deck can't fire
+       ON_FINALIZE on its own -- trigger it so the newly-exposed top window
+       picks up its focused decoration */
+    vk_widget_hide(widget);
+    vk_deck_finalize(vwm->deck);
+
+    if(vk_deck_get_top(vwm->deck) == NULL)
+        vwm_panel_set_status("Press Alt ~ for Menu");
+
+    vwm_minimized_refresh();
+    vk_screen_refresh(vwm->screen);
+}
+
+/*
+    Restore a minimized window: show it again and raise it to the top of the
+    deck (focus).
+*/
+void
+vwm_restore_window(vk_widget_t *widget)
+{
+    vwm_t   *vwm;
+
+    if(widget == NULL) return;
+
+    vwm = vwm_get_instance();
+
+    /* show, then raise: vk_deck_set_top() fires ON_FINALIZE, which repaints
+       the restored window as focused and demotes the previous top */
+    vk_widget_show(widget);
+    vk_deck_set_top(vwm->deck, widget);
+
+    vwm_minimized_refresh();
     vk_screen_refresh(vwm->screen);
 }
 
 void
 vwm_default_WINDOW_CYCLE(void)
 {
-    vwm_t       *vwm;
-    vk_widget_t *old_top;
-    vk_widget_t *new_top;
+    vwm_t   *vwm;
 
     vwm = vwm_get_instance();
 
-    old_top = vk_deck_get_top(vwm->deck);
+    /* cycling rotates the deck, firing ON_FINALIZE -- which repaints the
+       window rotating out of focus and the one rotating into it */
     vk_deck_cycle(vwm->deck, VK_VECTOR_LEFT);
-    new_top = vk_deck_get_top(vwm->deck);
-
-    if(old_top != NULL) vk_window_update(VK_WINDOW(old_top));
-    if(new_top != NULL) vk_window_update(VK_WINDOW(new_top));
 
     vk_screen_refresh(vwm->screen);
 }

--- a/winman.h
+++ b/winman.h
@@ -22,8 +22,12 @@ Press Alt ~ for Menu.  Press Alt+W to manage windows."
 void    vwm_default_VWM_START(void);
 void    vwm_default_VWM_STOP(void);
 
+int     vwm_on_deck_finalize(vk_object_t *object, int event, void *anything);
+
 void    vwm_default_WINDOW_CYCLE(void);
 void    vwm_default_WINDOW_CLOSE(vk_widget_t *widget);
+void    vwm_minimize_window(vk_widget_t *widget);
+void    vwm_restore_window(vk_widget_t *widget);
 
 void    vwm_default_WINDOW_MOVE_UP(vk_widget_t *widget);
 void    vwm_default_WINDOW_MOVE_DOWN(vk_widget_t *widget);


### PR DESCRIPTION
Minimized windows, built on libviper 5.5.0's deck finalize event.

* A title-bar minimize glyph (down-arrow; "v" on non-UTF-8) left of [X] hides a window in place.  A "(N) Minimized" panel pulldown next to VWM lists the hidden windows and restores one on click.  The Alt+W manage-windows tool gains Minimize/Restore buttons that act on the checked windows and flags already-minimized rows with the same arrow.  Restoring a window raises it and returns focus.
* Focus decoration is now driven by libviper's VK_EVENT_ON_FINALIZE: one handler repaints the focus borders whenever the deck's membership or stacking changes, replacing the demote-old-top / promote-new-top logic that was duplicated across raise, cycle, close, minimize, restore, cross-desktop move, and window spawn.  Border changes are immediate and can no longer fall out of sync.

Requires libviper 5.5.0+.