### PR TITLE
release: vwm 4.9.1

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,10 @@
+Version 4.9.1
+
+*  [Bryan Christ] Window title-bar controls now render as [v][X] -- the
+   minimize control is bracketed to match close -- and the pair is inset two
+   columns from the top-right corner rather than flush against it.  Each
+   button now has a full three-column click target (minimize was one column).
+
 Version 4.9.0
 
 *  [Bryan Christ] Minimized windows.  A window's title bar gains a minimize

--- a/poll_input_thd.c
+++ b/poll_input_thd.c
@@ -215,10 +215,13 @@ classify_mouse(vwm_t *vwm, int mx, int my, vk_widget_t **hit_out)
     rx = mx - wx;
     ry = my - wy;
 
-    if(ry == 0 && rx >= ww - (int)sizeof("[X]") + 1 && rx < ww)
+    /* top-border controls, right-aligned with a two-column corner margin:
+       [v][X]__ -- [X] spans ww-5..ww-3, [v] spans ww-8..ww-6, each 3 wide
+       (must track the drawing in vwm_window_decorate, private.c) */
+    if(ry == 0 && rx >= ww - 5 && rx <= ww - 3)
         return ZONE_CLOSE_BTN;
 
-    if(ry == 0 && rx == ww - (int)sizeof("[X]"))
+    if(ry == 0 && rx >= ww - 8 && rx <= ww - 6)
         return ZONE_MINIMIZE_BTN;
 
     state = vk_widget_get_state(hit);

--- a/private.c
+++ b/private.c
@@ -48,6 +48,7 @@ vwm_window_decorate(vk_window_t *window, WINDOW *canvas, void *anything)
     attr_t      attrs;
     short       dummy;
     int         row, col;
+    int         close_col, min_col;
     int         reserved;
 
     /* interior columns that are chrome, not terminal (a vterm's scrollbar);
@@ -101,18 +102,25 @@ vwm_window_decorate(vk_window_t *window, WINDOW *canvas, void *anything)
 
     wattron(canvas, COLOR_PAIR(pair) | extra);
 
-    mvwprintw(canvas, 0, x - (int)sizeof("[X]") + 1, "[X]");
+    /* window controls, right-aligned with a two-column margin from the
+       corner:  [v][X]__  (v = down arrow, 'v' on non-UTF-8).  Each button is
+       three cells wide -- see the matching hit-test in poll_input_thd.c. */
+    close_col = x - 2 - 3;          /* [X] ends two columns short of the corner */
+    min_col   = close_col - 3;      /* [v] sits immediately left of [X] */
 
-    /* minimize glyph, one column left of [X]: a down arrow (v on non-UTF-8) */
+    mvwprintw(canvas, 0, close_col, "[X]");
+
+    mvwaddch(canvas, 0, min_col, '[');
     if(vwm_has_utf8())
     {
         wch[0] = 0x2193;                        /* U+2193 DOWNWARDS ARROW */
         wch[1] = L'\0';
         setcchar(&cc, wch, extra, pair, NULL);
-        mvwadd_wch(canvas, 0, x - (int)sizeof("[X]"), &cc);
+        mvwadd_wch(canvas, 0, min_col + 1, &cc);
     }
     else
-        mvwaddch(canvas, 0, x - (int)sizeof("[X]"), 'v');
+        mvwaddch(canvas, 0, min_col + 1, 'v');
+    mvwaddch(canvas, 0, min_col + 2, ']');
 
     snprintf(buf, sizeof(buf), "[%d x %d]", x - 2 - reserved, y - 2);
     len = strlen(buf);

--- a/vwm.h
+++ b/vwm.h
@@ -11,7 +11,7 @@
 #include <vkmio.h>
 
 
-#define VWM_VERSION					"4.9.0"
+#define VWM_VERSION					"4.9.1"
 
 /* the kmio feature set vwm arms at startup and must re-arm whenever the
    outer terminal may have changed under us -- teleport to a new PTY, a


### PR DESCRIPTION
Title-bar window controls: render minimize as [v] to match [X], inset the [v][X] pair two columns from the top-right corner, and give each button a full three-column click target (minimize was one).