### PR TITLE
release: vwm 4.9.2

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,12 @@
+Version 4.9.2
+
+*  [Bryan Christ] Desktop backgrounds now render bright and 256-colour choices
+   correctly.  The surface background was handed to libviper as a chtype, whose
+   pair went through COLOR_PAIR() and truncated past 255 -- so a bright desktop
+   colour showed the wrong colour in the cells the terminal's hardware-scroll
+   optimisation exposes.  Adopts libviper 5.6.0's widened
+   vk_screen_set_surface_bkgd(wch, attrs, pair).  Requires libviper 5.6.0+.
+
 Version 4.9.1
 
 *  [Bryan Christ] Window title-bar controls now render as [v][X] -- the

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ REQUIREMENTS
 
 CMake
 ncursesw 5.4+
-libviper 5.5.0+  - https://github.com/TragicWarrior/libviper
+libviper 5.6.0+  - https://github.com/TragicWarrior/libviper
 libgpm (optional)
 libvterm 10.4+ - https://github.com/TragicWarrior/libvterm
 FreeType         (for the screen-capture module; "make all")

--- a/bkgd.c
+++ b/bkgd.c
@@ -618,7 +618,7 @@ vwm_apply_desktop_bkgd(int surface_id)
     pair = vdk_color_pair(COLOR_BLACK, bg);
 
     vk_screen_set_surface_bkgd(vwm->screen, surface_id,
-        ' ' | COLOR_PAIR(pair));
+        L' ', A_NORMAL, pair);
 }
 
 void

--- a/vwm.h
+++ b/vwm.h
@@ -11,7 +11,7 @@
 #include <vkmio.h>
 
 
-#define VWM_VERSION					"4.9.1"
+#define VWM_VERSION					"4.9.2"
 
 /* the kmio feature set vwm arms at startup and must re-arm whenever the
    outer terminal may have changed under us -- teleport to a new PTY, a


### PR DESCRIPTION
Adopt libviper 5.6.0's widened vk_screen_set_surface_bkgd.

vwm_apply_desktop_bkgd passed the surface background as a chtype (' ' | COLOR_PAIR(pair)), which truncated any pair > 255 -- so a bright desktop background (bg 12-15 -> vdk_color_pair 256-319) rendered in the wrong colour in the cells the terminal's hardware-scroll optimisation exposes.  Pass the decomposed (L' ', A_NORMAL, pair) to the new cchar_t/wbkgrndset path instead.

Requires libviper 5.6.0+.