### PR TITLE
fix: fit oversized windows back on screen after a shrink (4.9.4)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,14 @@
+Version 4.9.4
+
+*  [Bryan Christ] Fit an over-large window back on screen after a shrink -- a
+   dtach/abduco reattach or a teleport onto a smaller terminal, or restoring a
+   minimized window when the screen has shrunk.  Two steps: pull the top-left
+   back to the home corner, then, if the window is still larger than the usable
+   area, resize it down by the minimum needed to fit.  Previously such a window
+   kept its old size and stayed clipped.  New shared helper
+   vwm_fit_window_onscreen(), used by both the KEY_RESIZE clamp and the
+   minimized-restore path.
+
 Version 4.9.3
 
 *  [Bryan Christ] Track libviper 6.0.0's relief-API rename: the box-style

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,14 @@
+2026-07-06
+
+Windows no longer get stranded oversized after the terminal shrinks.  When you
+reattach a dtach/abduco session -- or teleport, or restore a minimized window --
+onto a terminal smaller than the window, vwm slides the window back to the
+top-left corner and, if it still doesn't fit, shrinks it just enough to fit on
+screen.  Before, an over-large window kept its size and spilled past the edges.
+
+Building this release needs libvterm 10.4+ and libviper 6.0.0+.
+
+
 2026-07-01
 
 Windows can be minimized.  Click the down-arrow on a window's title bar (just

--- a/poll_input_thd.c
+++ b/poll_input_thd.c
@@ -245,15 +245,13 @@ raise_to_top(vwm_t *vwm, vk_widget_t *widget)
 }
 
 /*
-    Pull every window's top-left back into the usable area (below the
-    panel row, above the status row, left edge on-screen).  After a
-    shrink -- e.g. a dtach reattach onto a smaller terminal -- windows
-    keep their old coordinates and one can end up with its title bar
-    off-screen, leaving no frame to grab and drag.  This is a pure
-    reposition; the window size (and any vterm child) is left alone, so a
-    window wider/taller than the new terminal stays clipped but its frame
-    is reachable.  No-op for windows that already fit, and runs across
-    every desktop so off-screen windows on inactive decks are fixed too.
+    Fit every window back into the usable area after a shrink -- e.g. a dtach
+    reattach or teleport onto a smaller terminal, which leaves windows at their
+    old coordinates and possibly larger than the new screen.  Each window's
+    top-left is pulled on-screen and, if it is still larger than the usable
+    area, shrunk just enough to fit (see vwm_fit_window_onscreen).  Runs across
+    every desktop so off-screen windows on inactive decks are fixed too; a
+    no-op for windows that already fit.
 */
 static void
 clamp_windows_onscreen(vwm_t *vwm)
@@ -274,23 +272,10 @@ clamp_windows_onscreen(vwm_t *vwm)
         for(i = 0; i < n; i++)
         {
             vk_widget_t *w = vk_deck_get_widget(deck, i);
-            int          wx, wy, ww, wh, nx, ny;
 
             if(w == NULL) continue;
 
-            vk_widget_get_position(w, &wx, &wy);
-            vk_widget_get_metrics(w, &ww, &wh);
-
-            nx = wx;
-            if(nx + ww > scr_w) nx = scr_w - ww;        /* pull left to fit */
-            if(nx < 0)          nx = 0;                 /* too wide: left-align */
-
-            ny = wy;
-            if(ny + wh > scr_h - 1) ny = scr_h - 1 - wh; /* clear the status row */
-            if(ny < 1)              ny = 1;              /* clear the panel row */
-
-            if(nx != wx || ny != wy)
-                vk_widget_move(w, nx, ny);
+            vwm_fit_window_onscreen(w, scr_w, scr_h);
         }
     }
 }

--- a/vwm.h
+++ b/vwm.h
@@ -11,7 +11,7 @@
 #include <vkmio.h>
 
 
-#define VWM_VERSION					"4.9.3"
+#define VWM_VERSION					"4.9.4"
 
 /* the kmio feature set vwm arms at startup and must re-arm whenever the
    outer terminal may have changed under us -- teleport to a new PTY, a

--- a/winman.c
+++ b/winman.c
@@ -150,6 +150,61 @@ vwm_minimize_window(vk_widget_t *widget)
 }
 
 /*
+    Fit a window into the usable area (row 0 is the panel, row scr_h-1 the
+    status bar; windows live in between).  Two steps, for a dtach reattach,
+    teleport, or restore onto a terminal smaller than the window was sized for:
+      1. pull the top-left back on-screen -- a window larger than the screen
+         clamps to the home corner (x = 0, y = 1);
+      2. if it is STILL larger than the usable area, shrink it by the minimum
+         needed to fit.  vk_widget_resize propagates to a vwmterm's vterm
+         child, the same path the +/-/</> resize hotkeys use.
+    A no-op for a window that already fits.  scr_w/scr_h come from getmaxyx on
+    the current SCREEN.
+*/
+void
+vwm_fit_window_onscreen(vk_widget_t *widget, int scr_w, int scr_h)
+{
+    int wx, wy, ww, wh, nx, ny, max_w, max_h, nw, nh;
+
+    if(widget == NULL) return;
+
+    vk_widget_get_position(widget, &wx, &wy);
+    vk_widget_get_metrics(widget, &ww, &wh);
+
+    /* step 1: reposition the top-left into the usable area */
+    nx = wx;
+    if(nx + ww > scr_w) nx = scr_w - ww;         /* pull left to fit    */
+    if(nx < 0)          nx = 0;                  /* too wide: home x     */
+
+    ny = wy;
+    if(ny + wh > scr_h - 1) ny = scr_h - 1 - wh; /* keep off status row */
+    if(ny < 1)              ny = 1;              /* keep off panel row   */
+
+    if(nx != wx || ny != wy)
+        vk_widget_move(widget, nx, ny);
+
+    /* step 2: still clipped at the home corner -> shrink to fit.  usable
+       width is scr_w - nx; usable height is (scr_h - 1) - ny. */
+    max_w = scr_w - nx;
+    max_h = (scr_h - 1) - ny;
+
+    nw = ww;
+    nh = wh;
+    if(nw > max_w) nw = max_w;
+    if(nh > max_h) nh = max_h;
+    if(nw < 3)     nw = 3;           /* frame minimum (cf. the resize hotkeys) */
+    if(nh < 3)     nh = 3;
+
+    if(nw != ww || nh != wh)
+    {
+        vk_widget_resize(widget, nw, nh);
+        vk_window_update(VK_WINDOW(widget));   /* re-render the frame at the
+                                                  new size, like the resize
+                                                  hotkeys do */
+    }
+}
+
+/*
     Restore a minimized window: show it again and raise it to the top of the
     deck (focus).
 */
@@ -157,10 +212,17 @@ void
 vwm_restore_window(vk_widget_t *widget)
 {
     vwm_t   *vwm;
+    int      scr_h, scr_w;
 
     if(widget == NULL) return;
 
     vwm = vwm_get_instance();
+
+    /* the terminal may have shrunk while this window was minimized -- fit it
+       back into the usable area (move home, then shrink if still clipped) so
+       it can't come back partly off-screen */
+    getmaxyx(vk_screen_get_window(vwm->screen), scr_h, scr_w);
+    vwm_fit_window_onscreen(widget, scr_w, scr_h);
 
     /* show, then raise: vk_deck_set_top() fires ON_FINALIZE, which repaints
        the restored window as focused and demotes the previous top */

--- a/winman.h
+++ b/winman.h
@@ -28,6 +28,7 @@ void    vwm_default_WINDOW_CYCLE(void);
 void    vwm_default_WINDOW_CLOSE(vk_widget_t *widget);
 void    vwm_minimize_window(vk_widget_t *widget);
 void    vwm_restore_window(vk_widget_t *widget);
+void    vwm_fit_window_onscreen(vk_widget_t *widget, int scr_w, int scr_h);
 
 void    vwm_default_WINDOW_MOVE_UP(vk_widget_t *widget);
 void    vwm_default_WINDOW_MOVE_DOWN(vk_widget_t *widget);


### PR DESCRIPTION
After a dtach/abduco reattach or a teleport onto a smaller terminal, or when restoring a minimized window on a shrunk screen, a window larger than the usable area is now fitted in two steps: pull the top-left back to the home corner, then, if it is still too big, resize it down by the minimum needed to fit. Previously such a window kept its old size and stayed clipped.

New shared helper vwm_fit_window_onscreen() in winman.c, used by both the KEY_RESIZE clamp (clamp_windows_onscreen, which also covers teleport via its queued KEY_RESIZE) and the minimized-restore path (vwm_restore_window).