### PR TITLE
fix: copy from scrollback instead of snapping to the live screen (4.9.5)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,14 @@
+Version 4.9.5
+
+*  [Bryan Christ] Selecting/copying text while scrolled back into vwmterm
+   history no longer snaps the view to the live screen.  The selection render
+   now draws at the current scroll position (vwmterm_scroll_render) instead of
+   always the live buffer, so the view stays put and the anchor lands on the
+   row you clicked; and the copy reads the composed scrollback view via
+   libvterm's new vterm_copy_scrollback() rather than the live-only
+   vterm_copy_buffer, so the copied text is the history you selected.  Requires
+   libvterm 10.7+.
+
 Version 4.9.4
 
 *  [Bryan Christ] Fit an over-large window back on screen after a shrink -- a

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,15 @@
+2026-07-07
+
+Copying text from vwmterm scrollback works correctly.  Previously, if you
+scrolled back into history and started a selection, the view jumped to the live
+screen -- so the copy began on the wrong row and grabbed live-screen text
+instead of the history you were looking at.  The view now stays where you
+scrolled, the selection anchors on the row you clicked, and the copied text is
+the scrolled-back content you selected.
+
+Building this release needs libvterm 10.7+ and libviper 6.0.0+.
+
+
 2026-07-06
 
 Windows no longer get stranded oversized after the terminal shrinks.  When you

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ CMake
 ncursesw 5.4+
 libviper 6.0.0+  - https://github.com/TragicWarrior/libviper
 libgpm (optional)
-libvterm 10.4+ - https://github.com/TragicWarrior/libvterm
+libvterm 10.7+ - https://github.com/TragicWarrior/libvterm
 FreeType         (for the screen-capture module; "make all")
 libcups2-dev     (for the print module; "make all")
 zlib             (for the big-font hostname module, vwmfont)

--- a/modules/vwmterm3/events.c
+++ b/modules/vwmterm3/events.c
@@ -41,6 +41,7 @@ static char     *clipboard = NULL;
 static size_t   clipboard_len = 0;
 
 static void     vwmterm_scroll_drag_apply(vk_widget_t *widget, int mx, int my);
+static void     vwmterm_scroll_render(vwmterm_data_t *vwmterm_data);
 
 void
 vwmterm_init_keycodes(void)
@@ -192,7 +193,10 @@ vwmterm_render_selection(vwmterm_data_t *vwmterm_data)
     win = vterm_wnd_get(vterm);
     vwmterm_grid_size(vwmterm_data, &width, &height);
 
-    vterm_wnd_update(vterm, -1, 0, VTERM_WND_RENDER_ALL);
+    /* render at the current scroll position, not always the live screen --
+       otherwise starting/dragging a selection while scrolled back snaps the
+       view to the bottom and the highlighted rows are the wrong ones */
+    vwmterm_scroll_render(vwmterm_data);
 
     if(vwmterm_data->sel_anchor_row < vwmterm_data->sel_end_row ||
        (vwmterm_data->sel_anchor_row == vwmterm_data->sel_end_row &&
@@ -238,7 +242,13 @@ vwmterm_copy_selection(vwmterm_data_t *vwmterm_data)
     int             len;
 
     vterm = vwmterm_data->vterm;
-    cells = vterm_copy_buffer(vterm, &rows, &cols);
+    /* copy from the same view the user sees: the composed scrollback matrix
+       when scrolled back, else the live buffer */
+    if(vwmterm_data->scroll_offset > 0)
+        cells = vterm_copy_scrollback(vterm, vwmterm_data->scroll_offset,
+                    &rows, &cols);
+    else
+        cells = vterm_copy_buffer(vterm, &rows, &cols);
     if(cells == NULL) return;
 
     if(vwmterm_data->sel_anchor_row < vwmterm_data->sel_end_row ||
@@ -338,13 +348,14 @@ static void
 vwmterm_exit_selection(vwmterm_data_t *vwmterm_data)
 {
     vwm_t   *vwm;
-    vterm_t *vterm = vwmterm_data->vterm;
 
     vwm = vwm_get_instance();
 
     vwmterm_data->frozen = 0;
 
-    vterm_wnd_update(vterm, -1, 0, VTERM_WND_RENDER_ALL);
+    /* leaving selection: stay at the scroll position the user was viewing
+       (scroll-aware) rather than jumping to the live screen */
+    vwmterm_scroll_render(vwmterm_data);
 
     vk_window_set_title(vwmterm_data->window, vwmterm_data->title);
 

--- a/vwm.h
+++ b/vwm.h
@@ -11,7 +11,7 @@
 #include <vkmio.h>
 
 
-#define VWM_VERSION					"4.9.4"
+#define VWM_VERSION					"4.9.5"
 
 /* the kmio feature set vwm arms at startup and must re-arm whenever the
    outer terminal may have changed under us -- teleport to a new PTY, a


### PR DESCRIPTION
Selecting/copying text while scrolled back into vwmterm history no longer jumps the view to the bottom. vwmterm_render_selection and vwmterm_exit_selection now render at the current scroll position (vwmterm_scroll_render) rather than always the live buffer, so the view stays put and the selection anchors on the row you clicked; and vwmterm_copy_selection reads the composed scrollback view via libvterm's new vterm_copy_scrollback() instead of the live-only vterm_copy_buffer, so the copied text is the history you selected.

Requires libvterm 10.7+; version 4.9.4 -> 4.9.5.