### PR TITLE
fix: resize the screen saver on terminal resize (4.9.6)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,17 @@
+Version 4.9.6
+
+*  [Bryan Christ] The screen saver now tracks a terminal resize.  While the
+   saver (a fullscreen vterm running the configured lock program) is up,
+   poll_input_thd previously swallowed KEY_RESIZE, so a dtach reattach onto a
+   different-size terminal left the saver -- and the locked program inside it --
+   stuck at the old geometry (e.g. vlock not filling a grown screen).  A resize
+   is now forwarded to the saver overlay only: vwm_screensaver_resize() resizes
+   the fullscreen vterm window (clearing its VK_STATE_NORESIZE for the
+   programmatic resize and growing its content child), which drives
+   vterm_resize() -> libvterm TIOCSWINSZ + SIGWINCH into the locked program so
+   it repaints at the new size.  The hidden desktop underneath is never
+   repainted, so a resize can't expose it.
+
 Version 4.9.5
 
 *  [Bryan Christ] Selecting/copying text while scrolled back into vwmterm

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,17 @@
 2026-07-07
 
+Resizing the terminal while the screen saver is up now works.  If you lock the
+screen (or the idle saver kicks in) and then reattach a dtach session at a
+different size -- or otherwise resize the terminal -- the saver and the locked
+program grow/shrink to fill the new screen instead of staying at the old size.
+Only the saver overlay is resized; the desktop it hides is never repainted, so
+the resize can't expose it.
+
+Building this release needs libvterm 10.7+ and libviper 6.0.0+.
+
+
+2026-07-07
+
 Copying text from vwmterm scrollback works correctly.  Previously, if you
 scrolled back into history and started a selection, the view jumped to the live
 screen -- so the copy began on the wrong row and grabbed live-screen text

--- a/poll_input_thd.c
+++ b/poll_input_thd.c
@@ -323,10 +323,22 @@ vwm_poll_input(void * const env)
             continue;
         }
 
-        /* while the screensaver is up, all input is locked to it */
+        /* while the screensaver is up, all input is locked to it -- EXCEPT a
+           terminal resize (e.g. a dtach reattach onto a different-size tty),
+           which we let through so the fullscreen saver overlay and the locked
+           program's vterm follow the new geometry.  Only the overlay is
+           resized; the desktop beneath stays hidden (no clamp/repaint of the
+           deck), so the lock is never broken by a resize. */
         if(vwm_screensaver_is_active())
         {
-            vwm_screensaver_input(keystroke, mouse_event);
+            if(keystroke == KEY_RESIZE)
+            {
+                vk_screen_resize(vwm->screen);
+                vwm_screensaver_resize();
+            }
+            else
+                vwm_screensaver_input(keystroke, mouse_event);
+
             vk_screen_refresh(vwm->screen);
             ctx_poll_input->did_work = 1;
             pt_yield(ctx_poll_input);

--- a/screensaver.c
+++ b/screensaver.c
@@ -81,16 +81,14 @@ screensaver_on_close(vk_object_t *object, int event, void *anything)
 
     s_last_activity = time(NULL);
 
-    /* The lock program (e.g. vlock) ran inside a fullscreen vterm while it
-       owned the screen, and vwm_screensaver_input swallowed KEY_RESIZE the
-       whole time it was up.  So if a dtach reattach happened DURING the lock
-       -- the common case, since the saver is usually what's running when you
-       vwm-resume -- the KEY_RESIZE that re-arms the terminal (mouse, cursor,
-       keypad, full repaint) was dropped, and vwm comes back with a dead
-       mouse and a visible cursor until a manual resize.  Now that the saver
-       is gone and s_active is false, queue one KEY_RESIZE so poll_input_thd
-       runs the resync cascade.  Idempotent -- and a welcome repaint -- even
-       when no reattach occurred (the user just unlocked locally). */
+    /* While locked, poll_input_thd forwards a KEY_RESIZE only to the saver
+       overlay (vwm_screensaver_resize) so the fullscreen lock tracks the new
+       geometry; the desktop beneath stays hidden and is NOT repainted.  So once
+       the saver is gone, queue one KEY_RESIZE to run the full resync cascade on
+       the now-revealed desktop: re-arm mouse/cursor/keypad (a dtach reattach
+       may have happened during the lock) and repaint + clamp the windows to the
+       current geometry.  Idempotent -- and a welcome repaint -- even when no
+       reattach occurred (a local unlock). */
     ungetch(KEY_RESIZE);
 
     return 0;
@@ -205,4 +203,43 @@ vwm_screensaver_input(int32_t keystroke, MEVENT *mouse_event)
     if(keystroke == KEY_MOUSE || keystroke == KEY_RESIZE) return;
 
     vk_object_push_keystroke(VK_OBJECT(s_window), keystroke);
+}
+
+/*
+    Resize the fullscreen saver overlay to the current screen size after a
+    geometry change (e.g. a dtach reattach onto a larger/smaller terminal).
+    The saver window is created VK_STATE_NORESIZE so the user can't resize it,
+    so clear that just for this programmatic resize.  The content child is
+    resized first so the window's VK_EVENT_ON_RESIZE handler (vwmterm) reads the
+    NEW interior and hands it to vterm_resize() -- libvterm then TIOCSWINSZ +
+    SIGWINCHes the locked program, which repaints itself at the new size.  Only
+    the overlay is touched; the hidden desktop below is never repainted, so the
+    lock is never broken by a resize.
+*/
+void
+vwm_screensaver_resize(void)
+{
+    vwm_t       *vwm = vwm_get_instance();
+    vk_widget_t *content;
+    uint32_t     state;
+    int          h, w;
+
+    if(!s_active || s_window == NULL) return;
+
+    getmaxyx(vk_screen_get_window(vwm->screen), h, w);
+    if(w < 1 || h < 1) return;
+
+    state = vk_widget_get_state(VK_WIDGET(s_window));
+    vk_widget_set_state(VK_WIDGET(s_window), state & ~VK_STATE_NORESIZE);
+
+    content = vk_window_get_child(s_window);
+    if(content != NULL)
+        vk_widget_resize(content, w, h);
+
+    vk_widget_resize(VK_WIDGET(s_window), w, h);
+    vk_widget_move(VK_WIDGET(s_window), 0, 0);
+
+    vk_widget_set_state(VK_WIDGET(s_window), state);
+
+    vk_window_update(s_window);
 }

--- a/screensaver.h
+++ b/screensaver.h
@@ -19,8 +19,13 @@ void    vwm_screensaver_activate(void);
 /* true while the screensaver is running (input is locked to it) */
 bool    vwm_screensaver_is_active(void);
 
-/* forward input to the running saver: keys go to its terminal, mouse and
-   resize are swallowed */
+/* forward input to the running saver: keys go to its terminal; mouse is
+   swallowed.  KEY_RESIZE is handled by vwm_screensaver_resize() instead. */
 void    vwm_screensaver_input(int32_t keystroke, MEVENT *mouse_event);
+
+/* resize the fullscreen saver overlay -- and the locked program's vterm -- to
+   the current screen size (e.g. after a dtach reattach onto a different-size
+   terminal).  Touches only the overlay, never the hidden desktop beneath it. */
+void    vwm_screensaver_resize(void);
 
 #endif

--- a/vwm.h
+++ b/vwm.h
@@ -11,7 +11,7 @@
 #include <vkmio.h>
 
 
-#define VWM_VERSION					"4.9.5"
+#define VWM_VERSION					"4.9.6"
 
 /* the kmio feature set vwm arms at startup and must re-arm whenever the
    outer terminal may have changed under us -- teleport to a new PTY, a


### PR DESCRIPTION
While the screen saver is up (a fullscreen vterm running the configured lock program, e.g. vlock), poll_input_thd swallowed KEY_RESIZE, so a dtach reattach onto a different-size terminal left the saver -- and the locked program inside its vterm -- stuck at the old geometry (e.g. vlock not filling a grown screen).

A resize is now forwarded to the saver overlay only: vwm_screensaver_resize() resizes the fullscreen vterm window to the new screen size (clearing its VK_STATE_NORESIZE for the programmatic resize and growing its content child), which drives vterm_resize() -> libvterm TIOCSWINSZ + SIGWINCH into the locked program so it repaints full-screen. The hidden desktop underneath is never repainted, so a resize can't expose it; the desktop is re-clamped/repainted only after unlock, via the existing queued KEY_RESIZE.

Version 4.9.5 -> 4.9.6.