### PR TITLE
feat(vwmterm): honor child OSC 52 clipboard SET (4.9.9)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,13 @@
+Version 4.9.9
+
+*  [Bryan Christ] Child OSC 52 SET (vim, Grok, tmux, Claude Code, …)
+   now feeds the same clipboard as SELECT-mode copy.  libvterm 10.9
+   delivers VTERM_EVENT_CLIPBOARD; vwmterm stores the payload for
+   middle-click / Alt+Shift+V and honors Settings clipboard_mode
+   (Never / OSC 52 / xclip / Both) for the host hop.  Pc p/s goes to
+   X PRIMARY; everything else to CLIPBOARD.  Empty Pd clears.
+   Requires libvterm 10.9+.
+
 Version 4.9.8
 
 *  [Bryan Christ] Menubar dropdowns now scroll with the mouse wheel (Apps, VWM,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,16 @@
+2026-08-14
+
+Copy from inside a terminal window now reaches the host clipboard.
+Programs that yank via OSC 52 -- vim, Grok, Claude Code, tmux with
+set-clipboard, and others -- used to have that sequence swallowed.
+vwm now takes it, keeps it for middle-click / Alt+Shift+V paste, and
+forwards it according to the existing Copy-to-Clipboard setting
+(Never / OSC 52 / xclip / Both).  Under xfce4-terminal, xclip or Both
+is still what actually lands on X.
+
+Building this release needs libvterm 10.9+ and libviper 6.0.0+.
+
+
 2026-08-05
 
 Manage Apps can set a default terminal size per app.  The Category row is now

--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ FEATURES
    with Alt+d.
 *  Embedded terminal windows (vwmterm) with scrollback -- a mouse scrollbar,
    wheel, and Alt+PgUp / Alt+PgDn -- click-drag SELECT-mode copy to the host
-   clipboard, and middle-click paste.
+   clipboard, child OSC 52 copy (vim, Grok, tmux, …) on the same path, and
+   middle-click paste.
 *  Menubar with two dropdowns: VWM (system tools) and Apps (user-configured
    launchers).  Reach it with the menubar hotkey or mouse.
 *  In-app configuration dialogs -- no editor required for common changes:
@@ -54,7 +55,7 @@ CMake
 ncursesw 5.4+
 libviper 6.0.0+  - https://github.com/TragicWarrior/libviper
 libgpm (optional)
-libvterm 10.7+ - https://github.com/TragicWarrior/libvterm
+libvterm 10.9+ - https://github.com/TragicWarrior/libvterm
 FreeType         (for the screen-capture module; "make all")
 libcups2-dev     (for the print module; "make all")
 zlib             (for the big-font hostname module, vwmfont)

--- a/modules/vwmterm3/events.c
+++ b/modules/vwmterm3/events.c
@@ -42,6 +42,12 @@ static size_t   clipboard_len = 0;
 
 static void     vwmterm_scroll_drag_apply(vk_widget_t *widget, int mx, int my);
 static void     vwmterm_scroll_render(vwmterm_data_t *vwmterm_data);
+static void     vwmterm_osc52_copy(const char *buf, size_t len, char selection);
+static void     vwmterm_xclip_copy(const char *buf, size_t len, char selection);
+static void     vwmterm_host_clipboard_push(const char *buf, size_t len,
+                    char selection);
+static void     vwmterm_clipboard_take(char *buf, size_t len, char selection);
+static void     vwmterm_vterm_hook(vterm_t *vterm, int event, void *anything);
 
 void
 vwmterm_init_keycodes(void)
@@ -76,14 +82,22 @@ static const char b64_alphabet[] =
     "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
 
 static void
-vwmterm_osc52_copy(const char *buf, size_t len)
+vwmterm_osc52_copy(const char *buf, size_t len, char selection)
 {
     char            *enc;
     size_t          enc_len;
     size_t          i, j;
     unsigned char   a, b, c;
+    char            pc;
 
-    if(buf == NULL || len == 0) return;
+    pc = (selection == '\0') ? 'c' : selection;
+
+    if(buf == NULL || len == 0)
+    {
+        fprintf(stdout, "\033]52;%c;\033\\", pc);
+        fflush(stdout);
+        return;
+    }
 
     enc_len = 4 * ((len + 2) / 3);
     enc = (char *)malloc(enc_len + 1);
@@ -113,7 +127,7 @@ vwmterm_osc52_copy(const char *buf, size_t len)
     }
     enc[j] = '\0';
 
-    fputs("\033]52;c;", stdout);
+    fprintf(stdout, "\033]52;%c;", pc);
     fputs(enc, stdout);
     fputs("\033\\", stdout);
     fflush(stdout);
@@ -131,17 +145,89 @@ vwmterm_osc52_copy(const char *buf, size_t len)
     screen; the failure is a silent no-op.
 */
 static void
-vwmterm_xclip_copy(const char *buf, size_t len)
+vwmterm_xclip_copy(const char *buf, size_t len, char selection)
 {
-    FILE *fp;
+    FILE        *fp;
+    const char  *cmd;
 
-    if(buf == NULL || len == 0) return;
+    if(selection == 'p' || selection == 's')
+        cmd = "xclip -selection primary 2>/dev/null";
+    else
+        cmd = "xclip -selection clipboard 2>/dev/null";
 
-    fp = popen("xclip -selection clipboard 2>/dev/null", "w");
+    fp = popen(cmd, "w");
     if(fp == NULL) return;
 
-    fwrite(buf, 1, len, fp);
+    if(buf != NULL && len > 0)
+        fwrite(buf, 1, len, fp);
+
     pclose(fp);
+}
+
+static void
+vwmterm_host_clipboard_push(const char *buf, size_t len, char selection)
+{
+    vwm_t   *vwm = vwm_get_instance();
+    int     mode = (vwm != NULL)
+        ? vwm->clipboard_mode
+        : VWM_CLIPBOARD_NEVER;
+
+    if(mode == VWM_CLIPBOARD_OSC52 || mode == VWM_CLIPBOARD_BOTH)
+        vwmterm_osc52_copy(buf, len, selection);
+    if(mode == VWM_CLIPBOARD_XCLIP || mode == VWM_CLIPBOARD_BOTH)
+        vwmterm_xclip_copy(buf, len, selection);
+}
+
+/*
+    take ownership of buf (NULL / len 0 clears).  always updates the
+    internal paste buffer; host sync follows Settings clipboard_mode.
+*/
+static void
+vwmterm_clipboard_take(char *buf, size_t len, char selection)
+{
+    if(clipboard != NULL) free(clipboard);
+    clipboard = buf;
+    clipboard_len = (buf != NULL) ? len : 0;
+
+    vwmterm_host_clipboard_push(clipboard, clipboard_len, selection);
+}
+
+void
+vwmterm_bind_vterm(vterm_t *vterm)
+{
+    if(vterm == NULL) return;
+
+    vterm_install_hook(vterm, vwmterm_vterm_hook);
+    vterm_set_event_mask(vterm, VTERM_MASK_CLIPBOARD);
+}
+
+static void
+vwmterm_vterm_hook(vterm_t *vterm, int event, void *anything)
+{
+    vterm_clipboard_t   *clip;
+    char                *copy;
+    char                sel;
+
+    (void)vterm;
+
+    if(event != VTERM_EVENT_CLIPBOARD) return;
+    if(anything == NULL) return;
+
+    clip = (vterm_clipboard_t *)anything;
+    sel = (clip->selection == '\0') ? 'c' : clip->selection;
+
+    if(clip->data == NULL || clip->len == 0)
+    {
+        vwmterm_clipboard_take(NULL, 0, sel);
+        return;
+    }
+
+    copy = (char *)malloc(clip->len + 1);
+    if(copy == NULL) return;
+
+    memcpy(copy, clip->data, clip->len);
+    copy[clip->len] = '\0';
+    vwmterm_clipboard_take(copy, clip->len, sel);
 }
 
 /*
@@ -345,21 +431,7 @@ vwmterm_copy_selection(vwmterm_data_t *vwmterm_data)
 
     buf[pos] = '\0';
 
-    if(clipboard != NULL) free(clipboard);
-    clipboard = buf;
-    clipboard_len = pos;
-
-    {
-        vwm_t   *vwm = vwm_get_instance();
-        int     mode = (vwm != NULL)
-            ? vwm->clipboard_mode
-            : VWM_CLIPBOARD_NEVER;
-
-        if(mode == VWM_CLIPBOARD_OSC52 || mode == VWM_CLIPBOARD_BOTH)
-            vwmterm_osc52_copy(clipboard, clipboard_len);
-        if(mode == VWM_CLIPBOARD_XCLIP || mode == VWM_CLIPBOARD_BOTH)
-            vwmterm_xclip_copy(clipboard, clipboard_len);
-    }
+    vwmterm_clipboard_take(buf, pos, 'c');
 
     for(int r = 0; r < rows; r++) free(cells[r]);
     free(cells);

--- a/modules/vwmterm3/events.h
+++ b/modules/vwmterm3/events.h
@@ -6,8 +6,12 @@
 #include <ncursesw/curses.h>
 
 #include <vdk.h>
+#include <vterm.h>
 
 void    vwmterm_init_keycodes(void);
+
+/* subscribe the vterm to OSC 52 clipboard events (libvterm 10.9+) */
+void    vwmterm_bind_vterm(vterm_t *vterm);
 
 void    vwmterm_window_update(vwmterm_data_t *vwmterm_data);
 

--- a/modules/vwmterm3/init.c
+++ b/modules/vwmterm3/init.c
@@ -309,6 +309,7 @@ vwmterm_main(vwm_module_t *mod)
     }
     vterm_set_pair_selector(vterm, vwmterm_pair_selector);
     vterm_set_colors(vterm, COLOR_WHITE, COLOR_BLACK);
+    vwmterm_bind_vterm(vterm);
 
     /* per-app scrollback override (Manage Apps); 0 keeps vterm's default
        history of 4x the terminal height */

--- a/vwm.h
+++ b/vwm.h
@@ -11,7 +11,7 @@
 #include <vkmio.h>
 
 
-#define VWM_VERSION					"4.9.8"
+#define VWM_VERSION					"4.9.9"
 
 /* the kmio feature set vwm arms at startup and must re-arm whenever the
    outer terminal may have changed under us -- teleport to a new PTY, a
@@ -50,8 +50,8 @@
 #define VWM_WALLPAPER_COUNT         7
 
 /* host clipboard sync mode (picked in Settings).  Controls whether a
-   SELECT-mode copy is also pushed to the host clipboard, and by what
-   transport. */
+   SELECT-mode copy or a child's OSC 52 SET is also pushed to the host
+   clipboard, and by what transport. */
 #define VWM_CLIPBOARD_NEVER         0
 #define VWM_CLIPBOARD_OSC52         1
 #define VWM_CLIPBOARD_XCLIP         2


### PR DESCRIPTION
Subscribe each vterm to VTERM_EVENT_CLIPBOARD. Store the payload for middle-click / Alt+Shift+V and forward it with the existing Settings clipboard mode (Never / OSC 52 / xclip / Both). Requires libvterm 10.9+.