### PR TITLE
feat: cascade new windows and attention flash (6.1.0)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,15 @@
+Version 6.1.0
+
+*  [Bryan Christ] New windows cascade +2 columns and +2 rows when they
+   would share another visible member's origin on the same deck, so a
+   second VTerm Color does not sit exactly on top of the first.
+   Fullscreen windows are left alone.
+*  [Bryan Christ] Attention flash: vwm-msg attention <id> (or launch
+   --attention) switches to that window and pulses its border about
+   every 1/2 s (white-on-red / black-on-yellow) until the user clicks
+   or types in it, it is closed or minimized, or attention-off.
+   list-windows reports "attention".
+
 Version 6.0.0
 
 *  [Bryan Christ] Control plane: Unix socket (VWM_CONTROL_SOCK, else

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,16 @@
+2026-08-17
+
+New windows no longer land on the exact same origin as another window
+on that desktop: they step +2 columns and +2 rows while they still fit.
+Fullscreen is unchanged.
+
+vwm-msg attention <id> (also launch --attention) raises that window and
+pulses its border until you click or type in it, or run attention-off.
+Use it when a launched terminal is waiting on you (password prompt).
+
+Building this release needs libvterm 10.9+ and libviper 7.2.0+.
+
+
 2026-08-16
 
 vwm can be driven from a shell (or an agent) with vwm-msg.  The

--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ shell -- including one inside a vwmterm -- run vwm-msg:
     vwm-msg send-keys <id> --text "ls -la" --enter
     vwm-msg capture <id>
     vwm-msg screenshot --target top
+    vwm-msg attention <id>
     vwm-msg close <id>
 
 See vwm-msg --help.  This is not the dtach socket (VWM_SOCK).

--- a/clock.c
+++ b/clock.c
@@ -10,6 +10,7 @@
 #include "panel.h"
 #include "screensaver.h"
 #include "signals.h"
+#include "winman.h"
 
 /*
     Two reattach/resize cases the poll loop can't see on its own, both
@@ -91,6 +92,16 @@ vwm_clock_driver(void * const env)
         vwm_panel_ON_CLOCK_TICK(vwm_panel_get_data());
         vwm_screensaver_tick();
         check_destination_resize(vwm);
+        if(vwm->attention != NULL)
+        {
+            vwm->attention_hold++;
+            if(vwm->attention_hold >= VWM_ATTENTION_TICKS)
+            {
+                vwm->attention_hold = 0;
+                vwm->attention_phase = !vwm->attention_phase;
+                vk_window_update(VK_WINDOW(vwm->attention));
+            }
+        }
         vk_screen_refresh(vwm->screen);
         ctx_timer->did_work = 1;
         pt_yield(ctx_timer);

--- a/ctl.c
+++ b/ctl.c
@@ -539,6 +539,8 @@ op_list_windows(int fd)
             cJSON_AddBoolToObject(row, "minimized", visible ? 0 : 1);
             cJSON_AddStringToObject(row, "kind",
                 (vk_widget_get_userptr(w) != NULL) ? "vterm" : "window");
+            cJSON_AddBoolToObject(row, "attention",
+                vwm_attention_is(w) ? 1 : 0);
             cJSON_AddItemToArray(arr, row);
         }
     }
@@ -907,7 +909,9 @@ op_launch(int fd, cJSON *req)
         return;
     }
 
-    vk_deck_add_widget(vwm->deck, VK_WIDGET(window), VK_DECK_TOP);
+    vwm_deck_add_window(vwm->deck, VK_WIDGET(window), VK_DECK_TOP);
+    if(ctl_json_bool(req, "attention", NULL))
+        vwm_attention_set(VK_WIDGET(window));
     vk_screen_refresh(vwm->screen);
 
     data = cJSON_CreateObject();
@@ -1104,7 +1108,9 @@ op_launch_app(int fd, cJSON *req)
         return;
     }
 
-    vk_deck_add_widget(vwm->deck, VK_WIDGET(window), VK_DECK_TOP);
+    vwm_deck_add_window(vwm->deck, VK_WIDGET(window), VK_DECK_TOP);
+    if(ctl_json_bool(req, "attention", NULL))
+        vwm_attention_set(VK_WIDGET(window));
     vk_screen_refresh(vwm->screen);
 
     data = cJSON_CreateObject();
@@ -1853,6 +1859,54 @@ op_screenshot(int fd, cJSON *req)
 }
 
 static void
+op_attention(int fd, cJSON *req)
+{
+    int         present;
+    int         off;
+    uint32_t    id;
+    vk_widget_t *w;
+
+    off = ctl_json_bool(req, "off", NULL);
+    id = ctl_json_u32(req, "id", &present);
+
+    if(off)
+    {
+        if(present && id != 0)
+        {
+            w = ctl_find_id(id, NULL);
+            if(w == NULL)
+            {
+                ctl_reply(fd, 0, NULL, "unknown id");
+                return;
+            }
+            vwm_attention_clear(w);
+        }
+        else
+            vwm_attention_clear(NULL);
+
+        vk_screen_refresh(vwm_get_instance()->screen);
+        ctl_reply(fd, 1, NULL, NULL);
+        return;
+    }
+
+    if(!present || id == 0)
+    {
+        ctl_reply(fd, 0, NULL, "missing id");
+        return;
+    }
+
+    w = ctl_find_id(id, NULL);
+    if(w == NULL)
+    {
+        ctl_reply(fd, 0, NULL, "unknown id");
+        return;
+    }
+
+    vwm_attention_set(w);
+    ctl_reply(fd, 1, NULL, NULL);
+}
+
+static void
 ctl_dispatch(int fd, cJSON *req)
 {
     const char  *op;
@@ -1881,6 +1935,7 @@ ctl_dispatch(int fd, cJSON *req)
     else if(strcmp(op, "send-keys") == 0)     op_send_keys(fd, req);
     else if(strcmp(op, "capture") == 0)       op_capture(fd, req);
     else if(strcmp(op, "screenshot") == 0)    op_screenshot(fd, req);
+    else if(strcmp(op, "attention") == 0)     op_attention(fd, req);
     else
         ctl_reply(fd, 0, NULL, "unknown op");
 }

--- a/launch_picker.c
+++ b/launch_picker.c
@@ -15,6 +15,7 @@
 #include "strings.h"
 #include "manage_ui_common.h"
 #include "launch_picker.h"
+#include "winman.h"
 
 /*
     A standalone modal file picker for the "%fd" launch token.  It reuses
@@ -166,9 +167,7 @@ launch_picker_launch(const char *fullpath)
     window = module->main(module);
     if(window != NULL)
     {
-        /* add at top; ON_FINALIZE decorates the new window as focused and
-           demotes the previous top */
-        vk_deck_add_widget(vwm->deck, VK_WIDGET(window), VK_DECK_TOP);
+        vwm_deck_add_window(vwm->deck, VK_WIDGET(window), VK_DECK_TOP);
         vk_screen_refresh(vwm->screen);
     }
 }

--- a/manage_windows.c
+++ b/manage_windows.c
@@ -733,7 +733,7 @@ move_apply(void)
         for(i = 0; i < n; i++)
         {
             vk_deck_remove_widget(vwm->decks[active_surface], checked[i]);
-            vk_deck_add_widget(vwm->decks[target_surface],
+            vwm_deck_add_window(vwm->decks[target_surface],
                 checked[i], VK_DECK_TOP);
         }
     }

--- a/modules.c
+++ b/modules.c
@@ -12,6 +12,7 @@
 #include "strings.h"
 #include "launch_picker.h"
 #include "list.h"
+#include "winman.h"
 
 #define X_MOD(modtype_val, modtype_text) modtype_text,
 char *mod_desc[] =
@@ -487,9 +488,9 @@ vwm_menu_helper(vk_widget_t *widget, void *anything)
 
     if(window != NULL)
     {
-        /* add at top; ON_FINALIZE decorates the new window as focused and
-           demotes the previous top */
-        vk_deck_add_widget(vwm->deck, VK_WIDGET(window), VK_DECK_TOP);
+        /* add at top; cascade if the origin matches another member.
+           ON_FINALIZE decorates the new window as focused. */
+        vwm_deck_add_window(vwm->deck, VK_WIDGET(window), VK_DECK_TOP);
         vk_screen_refresh(vwm->screen);
     }
 

--- a/poll_input_thd.c
+++ b/poll_input_thd.c
@@ -237,6 +237,8 @@ classify_mouse(vwm_t *vwm, int mx, int my, vk_widget_t **hit_out)
 static void
 raise_to_top(vwm_t *vwm, vk_widget_t *widget)
 {
+    vwm_attention_clear(widget);
+
     if(widget == vk_deck_get_top(vwm->deck)) return;
 
     /* set_top fires ON_FINALIZE, which repaints the outgoing and incoming
@@ -809,6 +811,7 @@ vwm_poll_input(void * const env)
 
             if(top != NULL)
             {
+                vwm_attention_clear(top);
                 vk_object_push_keystroke(VK_OBJECT(top), keystroke);
                 /*
                     fall-through keystrokes (no menubar / panel / dialog

--- a/private.c
+++ b/private.c
@@ -61,7 +61,21 @@ vwm_window_decorate(vk_window_t *window, WINDOW *canvas, void *anything)
 
     getmaxyx(canvas, y, x);
 
-    if(focused)
+    if(vwm->attention == VK_WIDGET(window))
+    {
+        extra = A_BOLD;
+        if(vwm->attention_phase)
+        {
+            pair = vdk_color_pair(COLOR_WHITE, COLOR_RED);
+            vk_window_set_border_colors(window, COLOR_WHITE, COLOR_RED);
+        }
+        else
+        {
+            pair = vdk_color_pair(COLOR_BLACK, COLOR_YELLOW);
+            vk_window_set_border_colors(window, COLOR_BLACK, COLOR_YELLOW);
+        }
+    }
+    else if(focused)
     {
         pair = vdk_color_pair(COLOR_WHITE, COLOR_MAGENTA);
         extra = A_BOLD;

--- a/private.h
+++ b/private.h
@@ -96,6 +96,13 @@ struct _vwm_s
 
     uint32_t                state;
 
+    /* window whose border is flashing to request user attention
+       (vwm-msg attention).  NULL = none.  attention_phase toggles
+       every VWM_ATTENTION_TICKS clock ticks (1/2 s). */
+    vk_widget_t             *attention;
+    int                     attention_phase;
+    int                     attention_hold;
+
     int                     cursor_x;
     int                     cursor_y;
     bool                    show_cursor;

--- a/vwm-msg.c
+++ b/vwm-msg.c
@@ -26,7 +26,7 @@ usage(FILE *fp)
         "  move <id> [--dx N] [--dy N] [--x N] [--y N]\n"
         "  resize <id> [--dw N] [--dh N] [--width N] [--height N]\n"
         "  launch --bin PATH [--profile NAME] [--width N] [--height N]\n"
-        "         [--scrollback N] [--start-home] [-- ARG...]\n"
+        "         [--scrollback N] [--start-home] [--attention] [-- ARG...]\n"
         "  list-apps\n"
         "  launch-app <title words...>\n"
         "  send-keys <id> [--type] [--enter] [--file PATH | --text STR | TEXT]\n"
@@ -35,6 +35,8 @@ usage(FILE *fp)
         "  capture <id> [--scrollback [N]] [--path FILE]\n"
         "      --scrollback with no N dumps all history plus the live screen\n"
         "  screenshot [--target screen|top] [--path FILE]\n"
+        "  attention <id>\n"
+        "  attention-off [id]\n"
         "\n"
         "Talks to VWM_CONTROL_SOCK, else ~/.config/vwm/control.sock.\n");
 }
@@ -499,6 +501,7 @@ main(int argc, char **argv)
         const char  *height = NULL;
         const char  *scrollback = NULL;
         int         start_home = 0;
+        int         attention = 0;
         int         dash = 0;
         int         i;
         char        esc_bin[PATH_MAX + 8];
@@ -559,6 +562,11 @@ main(int argc, char **argv)
                 start_home = 1;
                 continue;
             }
+            if(strcmp(argv[i], "--attention") == 0)
+            {
+                attention = 1;
+                continue;
+            }
 
             fprintf(stderr, "vwm-msg: unknown flag %s\n", argv[i]);
             return 1;
@@ -603,6 +611,8 @@ main(int argc, char **argv)
         }
         if(start_home)
             strncat(req, ",\"start_home\":1", sizeof(req) - 1);
+        if(attention)
+            strncat(req, ",\"attention\":true", sizeof(req) - 1);
         if(args_json[0] != '\0')
         {
             strncat(req, ",\"args\":[", sizeof(req) - 1);
@@ -951,6 +961,24 @@ main(int argc, char **argv)
         }
 
         snprintf(req, sizeof(req), "{\"op\":\"screenshot\"%s}", extra);
+        return transact(req);
+    }
+
+    if(strcmp(op, "attention") == 0)
+    {
+        if(need(argc, 2, "id") != 0) return 1;
+        snprintf(req, sizeof(req), "{\"op\":\"attention\",\"id\":%s}",
+            argv[2]);
+        return transact(req);
+    }
+
+    if(strcmp(op, "attention-off") == 0)
+    {
+        if(argc >= 3)
+            snprintf(req, sizeof(req),
+                "{\"op\":\"attention\",\"id\":%s,\"off\":true}", argv[2]);
+        else
+            snprintf(req, sizeof(req), "{\"op\":\"attention\",\"off\":true}");
         return transact(req);
     }
 

--- a/vwm.h
+++ b/vwm.h
@@ -13,7 +13,7 @@
 #include "screenshot.h"
 
 
-#define VWM_VERSION					"6.0.0"
+#define VWM_VERSION					"6.1.0"
 
 /* the kmio feature set vwm arms at startup and must re-arm whenever the
    outer terminal may have changed under us -- teleport to a new PTY, a
@@ -34,6 +34,8 @@
 
 #define VWM_CLOCK_TICK              (0.1F)
 #define VWM_CLOCK_TICKS_PER_SEC     ((short int)(1/VWM_CLOCK_TICK))
+/* hold each attention-flash color this many 0.1s clock ticks (1/2 s) */
+#define VWM_ATTENTION_TICKS         5
 
 #define VWM_STATE_NORMAL            0
 #define VMW_STATE_ASLEEP            (1 << 1)    // screensaver active

--- a/winman.c
+++ b/winman.c
@@ -134,6 +134,7 @@ vwm_default_WINDOW_CLOSE(vk_widget_t *widget)
     if(widget == NULL) return;
 
     vwm = vwm_get_instance();
+    vwm_attention_clear(widget);
     desk = vwm_widget_desktop(widget);
     deck = (desk >= 0) ? vwm->decks[desk] : vwm->deck;
     if(deck == NULL) return;
@@ -168,6 +169,7 @@ vwm_minimize_window(vk_widget_t *widget)
     if(widget == NULL) return;
 
     vwm = vwm_get_instance();
+    vwm_attention_clear(widget);
     desk = vwm_widget_desktop(widget);
     deck = (desk >= 0) ? vwm->decks[desk] : vwm->deck;
     if(deck == NULL) return;
@@ -362,6 +364,126 @@ vwm_default_WINDOW_DECREASE_HEIGHT(vk_widget_t *widget)
     vk_widget_resize(widget, width, height - 1);
     vk_window_update(VK_WINDOW(widget));
     vk_screen_refresh(vwm_get_instance()->screen);
+}
+
+#define VWM_CASCADE_DX  2
+#define VWM_CASCADE_DY  2
+
+static int
+cascade_origin_taken(vk_deck_t *deck, vk_widget_t *self, int x, int y)
+{
+    int     n, i;
+
+    n = vk_deck_count(deck);
+    for(i = 0; i < n; i++)
+    {
+        vk_widget_t *w;
+        int         ox, oy;
+
+        w = vk_deck_get_widget(deck, i);
+        if(w == NULL || w == self) continue;
+        if(!(vk_widget_get_state(w) & VK_STATE_VISIBLE)) continue;
+
+        vk_widget_get_position(w, &ox, &oy);
+        if(ox == x && oy == y)
+            return 1;
+    }
+
+    return 0;
+}
+
+static void
+cascade_place(vk_deck_t *deck, vk_widget_t *widget)
+{
+    vwm_t   *vwm;
+    int     x, y, ww, wh;
+    int     scr_w, scr_h;
+
+    if(deck == NULL || widget == NULL) return;
+    if(vk_widget_get_state(widget) & VK_STATE_NORESIZE)
+        return;
+
+    vwm = vwm_get_instance();
+    if(vwm == NULL || vwm->screen == NULL) return;
+
+    getmaxyx(vk_screen_get_window(vwm->screen), scr_h, scr_w);
+    vk_widget_get_position(widget, &x, &y);
+    vk_widget_get_metrics(widget, &ww, &wh);
+
+    while(cascade_origin_taken(deck, widget, x, y))
+    {
+        int nx = x + VWM_CASCADE_DX;
+        int ny = y + VWM_CASCADE_DY;
+
+        if(nx < 0 || ny < 1) break;
+        if(nx + ww > scr_w) break;
+        if(ny + wh > scr_h - 1) break;
+
+        x = nx;
+        y = ny;
+    }
+
+    vk_widget_move(widget, x, y);
+}
+
+int
+vwm_deck_add_window(vk_deck_t *deck, vk_widget_t *widget, int position)
+{
+    if(deck == NULL || widget == NULL) return -1;
+
+    cascade_place(deck, widget);
+    return vk_deck_add_widget(deck, widget, position);
+}
+
+void
+vwm_attention_clear(vk_widget_t *widget)
+{
+    vwm_t   *vwm = vwm_get_instance();
+
+    if(vwm == NULL) return;
+    if(widget != NULL && vwm->attention != widget) return;
+
+    if(vwm->attention == NULL) return;
+
+    vwm->attention = NULL;
+    vwm->attention_phase = 0;
+    vwm->attention_hold = 0;
+}
+
+void
+vwm_attention_set(vk_widget_t *widget)
+{
+    vwm_t       *vwm = vwm_get_instance();
+    int         desk;
+
+    if(vwm == NULL || widget == NULL) return;
+
+    desk = vwm_widget_desktop(widget);
+    if(desk < 0) return;
+
+    if(!(vk_widget_get_state(widget) & VK_STATE_VISIBLE))
+        vk_widget_show(widget);
+
+    if(vk_screen_get_active_surface(vwm->screen) != desk)
+        vk_screen_set_surface(vwm->screen, desk);
+
+    vk_deck_set_top(vwm->decks[desk], widget);
+
+    vwm->attention = widget;
+    vwm->attention_phase = 1;
+    vwm->attention_hold = 0;
+
+    vk_window_update(VK_WINDOW(widget));
+    vk_screen_refresh(vwm->screen);
+}
+
+int
+vwm_attention_is(vk_widget_t *widget)
+{
+    vwm_t   *vwm = vwm_get_instance();
+
+    if(vwm == NULL || widget == NULL) return 0;
+    return (vwm->attention == widget);
 }
 
 void

--- a/winman.h
+++ b/winman.h
@@ -32,6 +32,15 @@ void    vwm_restore_window(vk_widget_t *widget);
 int     vwm_widget_desktop(vk_widget_t *widget);
 void    vwm_fit_window_onscreen(vk_widget_t *widget, int scr_w, int scr_h);
 
+/* place then add: offset +2,+2 while another visible member shares
+   the same origin, if the window still fits.  fullscreen skipped. */
+int     vwm_deck_add_window(vk_deck_t *deck, vk_widget_t *widget,
+            int position);
+
+void    vwm_attention_set(vk_widget_t *widget);
+void    vwm_attention_clear(vk_widget_t *widget);
+int     vwm_attention_is(vk_widget_t *widget);
+
 void    vwm_default_WINDOW_MOVE_UP(vk_widget_t *widget);
 void    vwm_default_WINDOW_MOVE_DOWN(vk_widget_t *widget);
 void    vwm_default_WINDOW_MOVE_LEFT(vk_widget_t *widget);


### PR DESCRIPTION
Offset a newly added window +2,+2 while another visible member on the same deck shares its origin, so stacked launches do not sit exactly on top of each other. Fullscreen is unchanged.

vwm-msg attention <id> (or launch --attention) raises the window and pulses its border every 1/2 s until the user clicks or types in it, it is closed or minimized, or attention-off.