### PR TITLE
feat: reorient clipped windows and clamp vwm-msg size (6.1.1)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,15 @@
+Version 6.1.1
+
+*  [Bryan Christ] Manage Desktop -> Move -> Reorient (was Home
+   coordinates) now runs the same on-screen fit as restore: pull the
+   origin back, then shrink if the window is still clipped.  A window
+   hanging off the right or bottom edge can be recovered from the
+   picker, not only by minimize/restore.
+*  [Bryan Christ] vwm-msg launch / launch-app run that same fit after
+   spawn so a requested size cannot hang off the screen.  vwm-msg
+   resize clamps width/height to the remaining space from the window's
+   current origin (right edge on-screen, bottom above the status row).
+
 Version 6.1.0
 
 *  [Bryan Christ] New windows cascade +2 columns and +2 rows when they

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,21 @@
+2026-08-22
+
+Manage Desktop -> Move -> Reorient (was Home coordinates) uses the
+same fit as restore: pull the window origin on-screen, then shrink
+if it still hangs off the right or bottom edge.  That recovers a
+clipped window from the picker instead of leaving it stuck, which
+is what a hard move to (1, 1) used to do (ncurses mvwin refuses
+any destination that would still overflow).
+
+vwm-msg launch and launch-app run that fit after spawn.  vwm-msg
+resize no longer honors a width/height that would hang off the
+right edge or cover the status row -- it clamps to the remaining
+space from the window's current origin.  That was how an agent
+could open a window too large to move.
+
+Building this release needs libvterm 10.9+ and libviper 7.2.0+.
+
+
 2026-08-17
 
 New windows no longer land on the exact same origin as another window

--- a/ctl.c
+++ b/ctl.c
@@ -754,6 +754,68 @@ op_move(int fd, cJSON *req)
     ctl_reply(fd, 1, NULL, NULL);
 }
 
+/*
+    Screen geometry for clamp/fit.  Returns 0, or -1 if the SCREEN is
+    not usable.  Height includes the panel (row 0) and status (last
+    row); callers that size a window treat those as reserved.
+*/
+static int
+ctl_screen_size(int *scr_w, int *scr_h)
+{
+    vwm_t   *vwm = vwm_get_instance();
+    int     h, w;
+
+    if(vwm == NULL || vwm->screen == NULL) return -1;
+
+    getmaxyx(vk_screen_get_window(vwm->screen), h, w);
+    if(w < 3 || h < 3) return -1;
+
+    if(scr_w != NULL) *scr_w = w;
+    if(scr_h != NULL) *scr_h = h;
+    return 0;
+}
+
+/*
+    Cap a resize so the window stays on-screen from its current origin.
+    Right edge must not pass COLS; bottom must stay off the status row.
+    A size that would hang off is how windows became unmovable (mvwin
+    then refuses every later move).  Floor is 3, same as the resize
+    hotkeys / the old ctl minimum.
+*/
+static void
+ctl_clamp_metrics(vk_widget_t *w, int *ww, int *wh)
+{
+    int x, y, scr_w, scr_h, max_w, max_h;
+
+    if(w == NULL || ww == NULL || wh == NULL) return;
+    if(ctl_screen_size(&scr_w, &scr_h) != 0) return;
+
+    vk_widget_get_position(w, &x, &y);
+
+    max_w = scr_w - x;
+    max_h = (scr_h - 1) - y;
+    if(max_w < 3) max_w = 3;
+    if(max_h < 3) max_h = 3;
+
+    if(*ww > max_w) *ww = max_w;
+    if(*wh > max_h) *wh = max_h;
+    if(*ww < 3) *ww = 3;
+    if(*wh < 3) *wh = 3;
+}
+
+/* After launch: same on-screen fit as restore.  Skips fullscreen. */
+static void
+ctl_fit_new_window(vk_widget_t *w)
+{
+    int scr_w, scr_h;
+
+    if(w == NULL) return;
+    if(vk_widget_get_state(w) & VK_STATE_NORESIZE) return;
+    if(ctl_screen_size(&scr_w, &scr_h) != 0) return;
+
+    vwm_fit_window_onscreen(w, scr_w, scr_h);
+}
+
 static void
 op_resize(int fd, cJSON *req)
 {
@@ -789,6 +851,8 @@ op_resize(int fd, cJSON *req)
 
     if(ww < 3) ww = 3;
     if(wh < 3) wh = 3;
+
+    ctl_clamp_metrics(w, &ww, &wh);
 
     vk_widget_resize(w, ww, wh);
     vk_window_update(VK_WINDOW(w));
@@ -910,6 +974,7 @@ op_launch(int fd, cJSON *req)
     }
 
     vwm_deck_add_window(vwm->deck, VK_WIDGET(window), VK_DECK_TOP);
+    ctl_fit_new_window(VK_WIDGET(window));
     if(ctl_json_bool(req, "attention", NULL))
         vwm_attention_set(VK_WIDGET(window));
     vk_screen_refresh(vwm->screen);
@@ -1109,6 +1174,7 @@ op_launch_app(int fd, cJSON *req)
     }
 
     vwm_deck_add_window(vwm->deck, VK_WIDGET(window), VK_DECK_TOP);
+    ctl_fit_new_window(VK_WIDGET(window));
     if(ctl_json_bool(req, "attention", NULL))
         vwm_attention_set(VK_WIDGET(window));
     vk_screen_refresh(vwm->screen);

--- a/manage_windows.c
+++ b/manage_windows.c
@@ -707,11 +707,15 @@ move_apply(void)
 
     if(idx == 0)
     {
-        /* Home coordinates -- move every checked window to (1, 1) on the
-           current desktop (they stack) */
+        /* Reorient -- same fit as restore: pull the origin on-screen,
+           then shrink if the window is still clipped.  Leaves each
+           window on the current desktop. */
+        int scr_h, scr_w;
+
+        getmaxyx(vk_screen_get_window(vwm->screen), scr_h, scr_w);
         for(i = 0; i < n; i++)
         {
-            vk_widget_move(checked[i], 1, 1);
+            vwm_fit_window_onscreen(checked[i], scr_w, scr_h);
             vk_window_update(VK_WINDOW(checked[i]));
         }
         free(checked);
@@ -784,9 +788,9 @@ move_popup_open(void)
     desktops = vwm->surface_count;
 
     /*
-        always 1 row for "Home coordinates", plus 1 row per desktop when
+        always 1 row for "Reorient", plus 1 row per desktop when
         there is more than one.  cap the listbox at 6 rows so we never
-        run past the popup height (VWM_MAX_DESKTOPS == 6, "Home" + 6 = 7).
+        run past the popup height (VWM_MAX_DESKTOPS == 6, "Reorient" + 6 = 7).
     */
     lb_height = 1 + (desktops > 1 ? desktops : 0);
     if(lb_height > 7) lb_height = 7;
@@ -817,7 +821,7 @@ move_popup_open(void)
     vk_listbox_set_unfocused(move_listbox, COLOR_BLACK, COLOR_WHITE);
     vk_listbox_set_wrap(move_listbox, FALSE);
 
-    vk_listbox_add_item(move_listbox, "Home coordinates", NULL, NULL);
+    vk_listbox_add_item(move_listbox, "Reorient", NULL, NULL);
     if(desktops > 1)
     {
         for(i = 0; i < desktops; i++)

--- a/vwm.h
+++ b/vwm.h
@@ -13,7 +13,7 @@
 #include "screenshot.h"
 
 
-#define VWM_VERSION					"6.1.0"
+#define VWM_VERSION					"6.1.1"
 
 /* the kmio feature set vwm arms at startup and must re-arm whenever the
    outer terminal may have changed under us -- teleport to a new PTY, a


### PR DESCRIPTION
Manage Desktop Move -> Reorient runs the restore on-screen fit instead of a hard move to (1,1). vwm-msg launch/launch-app fit after spawn; resize clamps to remaining space so a large window cannot hang off the edge and become unmovable (ncurses mvwin).