### PR TITLE
fix: load libutil.so.1 or libc forkpty (6.1.2)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,11 @@
+Version 6.1.2
+
+*  [Bryan Christ] vwmterm init no longer treats a missing unversioned
+   libutil.so as fatal (glibc 2.34+ folded libutil into libc and
+   distros dropped that symlink).  Tries libutil.so, then
+   libutil.so.1, then accepts a libc that already provides forkpty.
+   Fixes GitHub issue #88.
+
 Version 6.1.1
 
 *  [Bryan Christ] Manage Desktop -> Move -> Reorient (was Home

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,15 @@
+2026-08-25
+
+vwmterm init no longer dies when the unversioned libutil.so symlink
+is missing (glibc 2.34+ merged libutil into libc).  It tries
+libutil.so, then libutil.so.1, and otherwise continues if libc
+already provides forkpty.  That was GitHub issue #88 -- a missing
+devel symlink used to take the whole window manager down because
+the terminal module would not register.
+
+Building this release needs libvterm 10.9+ and libviper 7.2.0+.
+
+
 2026-08-22
 
 Manage Desktop -> Move -> Reorient (was Home coordinates) uses the

--- a/modules/vwmterm3/init.c
+++ b/modules/vwmterm3/init.c
@@ -157,10 +157,22 @@ vwm_mod_init(const char *modpath)
 
     vwmterm_init_keycodes();
 
-	dynlib = dlopen("libutil.so", RTLD_LAZY | RTLD_GLOBAL);
+    /*
+        libutil used to export forkpty/openpty.  glibc 2.34 folded it
+        into libc and distros dropped the unversioned libutil.so
+        symlink, so a hard dlopen("libutil.so") fails even when the
+        symbols are already in the process (vwm is linked -lutil, and
+        libc itself provides forkpty).  Try the historical name, then
+        the SONAME, then accept a libc that already has forkpty.
+    */
+    dynlib = dlopen("libutil.so", RTLD_LAZY | RTLD_GLOBAL);
     if(dynlib == NULL)
+        dynlib = dlopen("libutil.so.1", RTLD_LAZY | RTLD_GLOBAL);
+
+    if(dynlib == NULL && dlsym(RTLD_DEFAULT, "forkpty") == NULL)
     {
-        fprintf(stderr, "[EE] Could not load libutil.so\n\r");
+        fprintf(stderr, "[EE] Could not load libutil.so, and libc does not "
+            "provide forkpty\n\r");
         return -1;
     }
 

--- a/vwm.h
+++ b/vwm.h
@@ -13,7 +13,7 @@
 #include "screenshot.h"
 
 
-#define VWM_VERSION					"6.1.1"
+#define VWM_VERSION					"6.1.2"
 
 /* the kmio feature set vwm arms at startup and must re-arm whenever the
    outer terminal may have changed under us -- teleport to a new PTY, a


### PR DESCRIPTION
Fixes #88.

vwmterm init treated a missing unversioned `libutil.so` as fatal. glibc 2.34 folded libutil into libc and distros dropped that symlink, so the terminal module would not register and vwm exited.

Init now tries `libutil.so`, then `libutil.so.1`, then continues if libc already provides `forkpty`.