### PR TITLE
build: CMake project is C-only so configure does not need a C++ compiler (6.1.4)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+Version 6.1.4
+
+*  [Bryan Christ] CMake project() is C-only (LANGUAGES C).  A fresh
+   configure no longer requires a C++ compiler; vwm has no C++ sources.
+
 Version 6.1.3
 
 *  [Bryan Christ] Control socket I/O is bounded and complete.  Accepted

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.10.2)
 
-project(vwm)
+project(vwm LANGUAGES C)
 
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall")
 set(PROJECT_DESCRIPTION "A window manager for the console.")

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,13 @@
 2026-08-26
 
+CMake no longer looks for a C++ compiler on a fresh configure.
+`project(vwm LANGUAGES C)` -- vwm is C-only.
+
+Building this release needs libvterm 10.9+ and libviper 7.2.0+.
+
+
+2026-08-26
+
 The vwm-msg control socket no longer hangs the window manager if a
 client connects and sends nothing, and large replies (capture,
 screenshot, list-apps) are no longer truncated on a short write.

--- a/vwm.h
+++ b/vwm.h
@@ -13,7 +13,7 @@
 #include "screenshot.h"
 
 
-#define VWM_VERSION					"6.1.3"
+#define VWM_VERSION					"6.1.4"
 
 /* the kmio feature set vwm arms at startup and must re-arm whenever the
    outer terminal may have changed under us -- teleport to a new PTY, a


### PR DESCRIPTION
`project(vwm)` enabled CXX by default, so a fresh cmake probed for a C++ compiler even though vwm has no C++ sources. `project(vwm LANGUAGES C)` stops that.